### PR TITLE
Support element screenshots for ScaleFactor != 1

### DIFF
--- a/query.go
+++ b/query.go
@@ -428,13 +428,17 @@ func Screenshot(sel interface{}, picbuf *[]byte, opts ...QueryOption) Action {
 			return ErrInvalidBoxModel
 		}
 
-		// scroll to node position
+		var pixRatio float64
+		err = EvaluateAsDevTools(getWindowDevicePixelRatioJS, &pixRatio).Do(ctxt, h)
+		if err != nil {
+			return err
+		}
+
 		var pos []int
 		err = EvaluateAsDevTools(fmt.Sprintf(scrollJS, int64(box.Margin[0]), int64(box.Margin[1])), &pos).Do(ctxt, h)
 		if err != nil {
 			return err
 		}
-
 		// take page screenshot
 		buf, err := page.CaptureScreenshot().Do(ctxt, h)
 		if err != nil {
@@ -447,10 +451,12 @@ func Screenshot(sel interface{}, picbuf *[]byte, opts ...QueryOption) Action {
 			return err
 		}
 
+		s := pixRatio
+
 		// crop to box model contents.
 		cropped := imaging.Crop(img, image.Rect(
-			int(box.Margin[0])-pos[0], int(box.Margin[1])-pos[1],
-			int(box.Margin[4])-pos[0], int(box.Margin[5])-pos[1],
+			int(box.Margin[0]*s)-int(float64(pos[0])*s), int(box.Margin[1]*s)-int(float64(pos[1])*s),
+			int(box.Margin[4]*s)-int(float64(pos[0])*s), int(box.Margin[5]*s)-int(float64(pos[1])*s),
 		))
 
 		// encode

--- a/util.go
+++ b/util.go
@@ -46,6 +46,10 @@ const (
 		return [window.scrollX, window.scrollY];
 	})(%d, %d)`
 
+	getWindowDevicePixelRatioJS = `(function(x, y) {
+		return window.devicePixelRatio;
+	})()`
+
 	// scrollIntoViewJS is a javascript snippet that scrolls the specified node
 	// into the window's viewport (if needed), returning the actual window x/y
 	// after execution.


### PR DESCRIPTION
This enables making screenshots of zoomed elements, for example to make
high-dpi screenshots.