### PR TITLE
Add WaitEventLoad action

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -59,3 +59,15 @@ func Sleep(d time.Duration) Action {
 		return nil
 	})
 }
+
+func WaitEventLoad() Action {
+	return ActionFunc(func(ctxt context.Context, h cdp.Handler) error {
+		select {
+		case <-h.WaitEventLoad():
+		case <-ctxt.Done():
+			return ctxt.Err()
+		}
+		return nil
+	})
+
+}

--- a/cdp/cdp.go
+++ b/cdp/cdp.go
@@ -1406,6 +1406,9 @@ type Handler interface {
 	// WaitNode waits for a node to be available.
 	WaitNode(context.Context, *Frame, NodeID) (*Node, error)
 
+	ResetEventLoad()
+	WaitEventLoad() <-chan struct{}
+
 	// Execute executes the specified command using the supplied context and
 	// parameters.
 	Execute(context.Context, MethodType, easyjson.Marshaler, easyjson.Unmarshaler) error

--- a/nav.go
+++ b/nav.go
@@ -11,6 +11,14 @@ import (
 // Navigate navigates the current frame.
 func Navigate(urlstr string) Action {
 	return ActionFunc(func(ctxt context.Context, h cdp.Handler) error {
+		// Immediately trigger anyone waiting on previous page loads,
+		// and reset the event pipeline. This ensures that previous
+		// waits don't get fired because of the page load coming in the
+		// future due to this Navigate() call - AND it ensures that
+		// future calls to WaitEventLoad won't fire due to previous
+		// navigations.
+		h.ResetEventLoad()
+
 		frameID, err := page.Navigate(urlstr).Do(ctxt, h)
 		if err != nil {
 			return err


### PR DESCRIPTION
This is a follow up to [my comments on #64](https://github.com/knq/chromedp/pull/64#issuecomment-309056121). It probably doesn't make sense to merge this PR before #77 is completed, but I wanted to put this out there for feedback and review.

I don't expect this PR to be merged as is, it's just a concept at this stage. I think the obvious thing to do is to generalise it to enable waiting on any kind of event. I don't yet know how to do this in particular because I'm not sure what the potential use cases are.

If this PR or a variant of it is merged, I would recommend removing the existing [`Listen`/`Release` stubs](https://github.com/knq/chromedp/blob/4cc4ba1ca23fb669e5ec66cda5c2bcdc3c10f672/handler.go#L668-L676).

The main approach with this PR is to put careful consideration into race conditions, and trying to marry up the load event with the appropriate navigation event. I'm not certain that this implementation is correct or the best form to put this in. I just wanted to get the conversation started. There are likely other use cases which are not convered, e.g, navigation events which are caused by things other than a `Navigate.Do` such as form submission, etc, which might be a good idea to consider in more detail.

Example use case:

```go
cdp.Tasks{
	cdp.Navigate("http://localhost:8080/foo"),
	cdp.WaitEventLoad(),
	cdp.CaptureScreenshot(&buf),
	saveScreenshot("foo.png"),

	cdp.Navigate("http://localhost:8080/bar"),
	cdp.WaitEventLoad(),
	cdp.CaptureScreenshot(&buf),
	saveScreenshot("bar.png"),

	...
}
```

I have been using this for a few days now, and I appear to reliably and quickly get screenshot of completed pages. This approach has the advantage over the traditional `WaitVisible` that it doesn't require polling (instead it is reacting to the browser declaring that the page has loaded) - so it's a bit faster, and it doesn't require page-specific knowledge about what can be waited on.


Do not merge before #77.
---