### PR TITLE
Fixed missing `return nil`

### DIFF
--- a/chromedp.go
+++ b/chromedp.go
@@ -237,6 +237,7 @@ func (c *CDP) SetHandlerByID(id string) error {
 
 	if i, ok := c.handlerMap[id]; ok {
 		c.cur = c.handlers[i]
+		return nil
 	}
 
 	return fmt.Errorf("no handler associated with target id %s", id)


### PR DESCRIPTION
The func SetHandlerByID always return a error.