### PR TITLE
Add optional network events listener

### DIFF
--- a/chromedp.go
+++ b/chromedp.go
@@ -14,10 +14,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/BrightLocal/chromedp/client"
+	"github.com/BrightLocal/chromedp/runner"
 	"github.com/chromedp/cdproto/cdp"
-
-	"github.com/chromedp/chromedp/client"
-	"github.com/chromedp/chromedp/runner"
 )
 
 const (

--- a/chromedp_test.go
+++ b/chromedp_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/chromedp/chromedp/runner"
+	"github.com/BrightLocal/chromedp/runner"
 )
 
 var (

--- a/handler.go
+++ b/handler.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/BrightLocal/chromedp/client"
 	"github.com/chromedp/cdproto"
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/css"
@@ -19,7 +20,6 @@ import (
 	"github.com/chromedp/cdproto/network"
 	"github.com/chromedp/cdproto/page"
 	"github.com/chromedp/cdproto/runtime"
-	"github.com/chromedp/chromedp/client"
 	"github.com/mailru/easyjson"
 )
 

--- a/handler.go
+++ b/handler.go
@@ -10,18 +10,17 @@ import (
 	"sync"
 	"time"
 
-	"github.com/mailru/easyjson"
-
 	"github.com/chromedp/cdproto"
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/css"
 	"github.com/chromedp/cdproto/dom"
 	"github.com/chromedp/cdproto/inspector"
 	"github.com/chromedp/cdproto/log"
+	"github.com/chromedp/cdproto/network"
 	"github.com/chromedp/cdproto/page"
 	"github.com/chromedp/cdproto/runtime"
-
 	"github.com/chromedp/chromedp/client"
+	"github.com/mailru/easyjson"
 )
 
 // TargetHandler manages a Chrome DevTools Protocol target.
@@ -42,6 +41,9 @@ type TargetHandler struct {
 
 	// qevents is the incoming event queue.
 	qevents chan *cdproto.Message
+
+	// netevents is for incoming network events
+	netevents chan interface{}
 
 	// detached is closed when the detached event is received.
 	detached chan *inspector.EventDetached
@@ -101,7 +103,7 @@ func (h *TargetHandler) Run(ctxt context.Context) error {
 	for _, a := range []Action{
 		log.Enable(),
 		runtime.Enable(),
-		//network.Enable(),
+		network.Enable(),
 		inspector.Enable(),
 		page.Enable(),
 		dom.Enable(),
@@ -247,7 +249,7 @@ func (h *TargetHandler) processEvent(ctxt context.Context, msg *cdproto.Message)
 	}
 
 	d := msg.Method.Domain()
-	if d != "Page" && d != "DOM" {
+	if d != "Page" && d != "DOM" && d != "Network" {
 		return nil
 	}
 
@@ -259,6 +261,11 @@ func (h *TargetHandler) processEvent(ctxt context.Context, msg *cdproto.Message)
 	case "DOM":
 		h.domWaitGroup.Add(1)
 		go h.domEvent(ctxt, ev)
+
+	case "Network":
+		if h.netevents != nil {
+			h.netevents <- ev
+		}
 	}
 
 	return nil
@@ -388,6 +395,14 @@ func (h *TargetHandler) next() int64 {
 	defer h.lastm.Unlock()
 	h.last++
 	return h.last
+}
+
+// NetEvents returns read-only channel for all network events
+func (h *TargetHandler) NetEvents() <-chan interface{} {
+	if h.netevents == nil {
+		h.netevents = make(chan interface{})
+	}
+	return (<-chan interface{})(h.netevents)
 }
 
 // GetRoot returns the current top level frame's root document node.

--- a/input.go
+++ b/input.go
@@ -9,7 +9,7 @@ import (
 	"github.com/chromedp/cdproto/dom"
 	"github.com/chromedp/cdproto/input"
 
-	"github.com/chromedp/chromedp/kb"
+	"github.com/BrightLocal/chromedp/kb"
 )
 
 // MouseAction is a mouse action.

--- a/kb/gen.go
+++ b/kb/gen.go
@@ -16,7 +16,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/chromedp/chromedp/kb"
+	"github.com/BrightLocal/chromedp/kb"
 )
 
 var (

--- a/pool.go
+++ b/pool.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"sync"
 
-	"github.com/chromedp/chromedp/runner"
+	"github.com/BrightLocal/chromedp/runner"
 )
 
 // Pool manages a pool of running Chrome processes.

--- a/query_test.go
+++ b/query_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/chromedp/cdproto/css"
 	"github.com/chromedp/cdproto/dom"
 
-	"github.com/chromedp/chromedp/kb"
+	"github.com/BrightLocal/chromedp/kb"
 )
 
 func TestNodes(t *testing.T) {

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -12,7 +12,7 @@ import (
 	"sync"
 	"syscall"
 
-	"github.com/chromedp/chromedp/client"
+	"github.com/BrightLocal/chromedp/client"
 )
 
 const (


### PR DESCRIPTION
Add support for getting network events:
```go
chrome, _ := chromedp.New(ctx, options...)
chrome.Run(ctx, chromedp.ActionFunc(func(_ context.Context, h cdp.Executor) error {
	go func() {
		for evt := range h.(*chromedp.TargetHandler).NetEvents() {
			switch e := evt.(type) {
			case *network.EventRequestWillBeSent:
				log.Printf("Sending %s request to %s", e.Request.Method, e.Request.URL)
			case *network.EventResponseReceived:
				log.Printf("Got %d response from %s", e.Response.Status, e.Response.URL)
			}
		}
	}()
	return nil
}))
```