### PR TITLE
Event handler: CDP option for exposing events to a consumer

### DIFF
--- a/chromedp.go
+++ b/chromedp.go
@@ -143,7 +143,11 @@ func (c *CDP) AddTarget(ctxt context.Context, t client.Target) {
 		c.errf("could not create handler for %s: %v", t, err)
 		return
 	}
-	h.send = cdpEventForwarder(t.GetID(), c.events)
+
+	// add event forwarder, if we have an event channel
+	if c.events != nil {
+		h.send = cdpEventForwarder(t.GetID(), c.events)
+	}
 
 	// run
 	if err := h.Run(ctxt); err != nil {

--- a/chromedp.go
+++ b/chromedp.go
@@ -143,7 +143,7 @@ func (c *CDP) AddTarget(ctxt context.Context, t client.Target) {
 		c.errf("could not create handler for %s: %v", t, err)
 		return
 	}
-	h.event = cdpEventForwarder(t.GetID(), c.events)
+	h.send = cdpEventForwarder(t.GetID(), c.events)
 
 	// run
 	if err := h.Run(ctxt); err != nil {

--- a/chromedp.go
+++ b/chromedp.go
@@ -183,6 +183,10 @@ func (c *CDP) Shutdown(ctxt context.Context, opts ...client.Option) error {
 		return c.r.Shutdown(ctxt, opts...)
 	}
 
+	if c.events != nil {
+		close(c.events)
+	}
+
 	return nil
 }
 

--- a/chromedp.go
+++ b/chromedp.go
@@ -52,7 +52,7 @@ type CDP struct {
 	cur cdp.Executor
 
 	// events is the channel for piping cdproto events from handler to consumer
-	events chan<- *CDPEvent
+	events chan<- *Event
 
 	// handlers is the active handlers.
 	handlers []*TargetHandler
@@ -146,7 +146,7 @@ func (c *CDP) AddTarget(ctxt context.Context, t client.Target) {
 
 	// add event forwarder, if we have an event channel
 	if c.events != nil {
-		h.send = cdpEventForwarder(t.GetID(), c.events)
+		h.send = eventForwarder(t.GetID(), c.events)
 	}
 
 	// run
@@ -430,9 +430,9 @@ func WithLog(f func(string, ...interface{})) Option {
 	}
 }
 
-// WithEvents is a CDP option that sets the event channel through which a
+// WithEventChannel is a CDP option that sets the event channel through which a
 // handler may send CDP event messages.
-func WithEvents(ev chan<- *CDPEvent) Option {
+func WithEventChannel(ev chan<- *Event) Option {
 	return func(c *CDP) error {
 		c.events = ev
 		return nil

--- a/events.go
+++ b/events.go
@@ -14,11 +14,11 @@ type CDPEvent struct {
 // to forward *CDPEvents over the given channel
 func cdpEventForwarder(id string, ch chan<- *CDPEvent) func(msg *cdproto.Message) {
 	return func(msg *cdproto.Message) {
-		ev := &CDPEvent{
-			id:  id,
-			msg: msg,
-		}
 		if ch != nil {
+			ev := &CDPEvent{
+				id:  id,
+				msg: msg,
+			}
 			ch <- ev
 		}
 	}

--- a/events.go
+++ b/events.go
@@ -10,6 +10,20 @@ type CDPEvent struct {
 	msg *cdproto.Message
 }
 
+// cdpEventForwarder returns a function that can be called for a target handler
+// to forward *CDPEvents over the given channel
+func cdpEventForwarder(id string, ch chan<- *CDPEvent) func(msg *cdproto.Message) {
+	return func(msg *cdproto.Message) {
+		ev := &CDPEvent{
+			id:  id,
+			msg: msg,
+		}
+		if ch != nil {
+			ch <- ev
+		}
+	}
+}
+
 // ID returns the target ID of the event
 func (e *CDPEvent) ID() string {
 	return e.id

--- a/events.go
+++ b/events.go
@@ -1,0 +1,21 @@
+package chromedp
+
+import (
+	"github.com/chromedp/cdproto"
+)
+
+// CDPEvent is a CDP event originating from a target handler
+type CDPEvent struct {
+	id  string
+	msg *cdproto.Message
+}
+
+// ID returns the target ID of the event
+func (e *CDPEvent) ID() string {
+	return e.id
+}
+
+// Message returns the message associated with the event
+func (e *CDPEvent) Message() *cdproto.Message {
+	return e.msg
+}

--- a/events.go
+++ b/events.go
@@ -4,32 +4,32 @@ import (
 	"github.com/chromedp/cdproto"
 )
 
-// CDPEvent is a CDP event originating from a target handler
-type CDPEvent struct {
-	id  string
-	msg *cdproto.Message
+// Event is a CDP event originating from a target handler
+type Event struct {
+	targetID string
+	msg      *cdproto.Message
 }
 
-// cdpEventForwarder returns a function that can be called for a target handler
+// eventForwarder returns a function that can be called for a target handler
 // to forward *CDPEvents over the given channel
-func cdpEventForwarder(id string, ch chan<- *CDPEvent) func(msg *cdproto.Message) {
+func eventForwarder(tid string, ch chan<- *Event) func(msg *cdproto.Message) {
 	return func(msg *cdproto.Message) {
 		if ch != nil {
-			ev := &CDPEvent{
-				id:  id,
-				msg: msg,
+			ev := &Event{
+				targetID: tid,
+				msg:      msg,
 			}
 			ch <- ev
 		}
 	}
 }
 
-// ID returns the target ID of the event
-func (e *CDPEvent) ID() string {
-	return e.id
+// Message returns the message associated with the event
+func (e *Event) Message() *cdproto.Message {
+	return e.msg
 }
 
-// Message returns the message associated with the event
-func (e *CDPEvent) Message() *cdproto.Message {
-	return e.msg
+// TargetID returns the target TargetID of the event
+func (e *Event) TargetID() string {
+	return e.targetID
 }

--- a/handler.go
+++ b/handler.go
@@ -43,8 +43,8 @@ type TargetHandler struct {
 	// qevents is the incoming event queue.
 	qevents chan *cdproto.Message
 
-	// events is the events channel to promote events to the CDP.
-	events chan<- *cdproto.Message
+	// event publishes a message to the CDP.
+	event func(msg *cdproto.Message)
 
 	// detached is closed when the detached event is received.
 	detached chan *inspector.EventDetached
@@ -186,8 +186,8 @@ func (h *TargetHandler) run(ctxt context.Context) {
 				h.errf("could not process event %s: %v", ev.Method, err)
 			}
 
-			if h.events != nil {
-				h.events <- ev
+			if h.event != nil {
+				h.event(ev)
 			}
 
 		case res := <-h.qres:

--- a/handler.go
+++ b/handler.go
@@ -43,6 +43,9 @@ type TargetHandler struct {
 	// qevents is the incoming event queue.
 	qevents chan *cdproto.Message
 
+	// events is the events channel to promote events to the CDP.
+	events chan<- *cdproto.Message
+
 	// detached is closed when the detached event is received.
 	detached chan *inspector.EventDetached
 
@@ -181,6 +184,10 @@ func (h *TargetHandler) run(ctxt context.Context) {
 			err := h.processEvent(ctxt, ev)
 			if err != nil {
 				h.errf("could not process event %s: %v", ev.Method, err)
+			}
+
+			if h.events != nil {
+				h.events <- ev
 			}
 
 		case res := <-h.qres:

--- a/handler.go
+++ b/handler.go
@@ -43,8 +43,8 @@ type TargetHandler struct {
 	// qevents is the incoming event queue.
 	qevents chan *cdproto.Message
 
-	// event publishes a message to the CDP.
-	event func(msg *cdproto.Message)
+	// send publishes a message to the CDP.
+	send func(msg *cdproto.Message)
 
 	// detached is closed when the detached event is received.
 	detached chan *inspector.EventDetached
@@ -186,8 +186,8 @@ func (h *TargetHandler) run(ctxt context.Context) {
 				h.errf("could not process event %s: %v", ev.Method, err)
 			}
 
-			if h.event != nil {
-				h.event(ev)
+			if h.send != nil {
+				h.send(ev)
 			}
 
 		case res := <-h.qres:


### PR DESCRIPTION
This change allows a consumer to create a `chromedp.CDP` with an optional channel (using a function defined as `func WithEvents(ev chan<- *CDPEvent) Option`) for consuming events.

A `CDPEvent` struct was created and used as the container for the event (`cdproto.Message`) so that the target ID can accompany it, telling us what target (tab) the event came from.

Subscribing to the event stream is completely optional and will not affect current users.