### PR TITLE
chromedp: fix SetHandlerByID

### DIFF
--- a/chromedp.go
+++ b/chromedp.go
@@ -239,6 +239,7 @@ func (c *CDP) SetHandlerByID(id string) error {
 
 	if i, ok := c.handlerMap[id]; ok {
 		c.cur = c.handlers[i]
+		return nil
 	}
 
 	return fmt.Errorf("no handler associated with target id %s", id)


### PR DESCRIPTION
Don't fall through and return an error if we found a handler with a
matching ID.