### PR TITLE
use buffered chan for h.detached

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -89,7 +89,7 @@ func (h *TargetHandler) Run(ctxt context.Context) error {
 	h.qres = make(chan *cdproto.Message)
 	h.qevents = make(chan *cdproto.Message)
 	h.res = make(map[int64]chan *cdproto.Message)
-	h.detached = make(chan *inspector.EventDetached)
+	h.detached = make(chan *inspector.EventDetached, 1)
 	h.pageWaitGroup = new(sync.WaitGroup)
 	h.domWaitGroup = new(sync.WaitGroup)
 	h.Unlock()


### PR DESCRIPTION
this patch fixed goroutine leaks when processing detached event.

224 // processEvent processes an incoming event.
225 func (h *TargetHandler) processEvent(ctxt context.Context, msg *cdproto.Message) error {
...
235 
236     switch e := ev.(type) {
237     case *inspector.EventDetached:
238         h.Lock()
239         defer h.Unlock()
240         h.detached <- e   **the socket may have closed, event pushed goroutine returns, blocking here.**
