### PR TITLE
Added SIGTERM to linux systems on shutdown

### DIFF
--- a/runner/runner.go
+++ b/runner/runner.go
@@ -241,12 +241,15 @@ func (r *Runner) Shutdown(ctxt context.Context, opts ...client.Option) error {
 		}
 	}
 
-	// osx applications do not automatically exit when all windows (ie, tabs)
+	// osx and linux applications do not automatically exit when all windows (ie, tabs)
 	// closed, so send SIGTERM.
 	//
 	// TODO: add other behavior here for more process options on shutdown?
-	if runtime.GOOS == "darwin" && r.cmd != nil && r.cmd.Process != nil {
-		return r.cmd.Process.Signal(syscall.SIGTERM)
+	if r.cmd != nil && r.cmd.Process != nil {
+		switch runtime.GOOS {
+		case "darwin", "linux":
+			return r.cmd.Process.Signal(syscall.SIGTERM)
+		}
 	}
 
 	return nil

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -213,7 +213,8 @@ func (r *Runner) Start(ctxt context.Context, opts ...string) error {
 	return nil
 }
 
-// Shutdown shuts down the Chrome process.
+// Shutdown shuts down the Chrome process.  Currently only has support for
+// SIGTERM in darwin and linux systems
 func (r *Runner) Shutdown(ctxt context.Context, opts ...client.Option) error {
 	var err error
 


### PR DESCRIPTION
Running this on a Ubuntu 18, I noticed that the .Shutdown() function wasn't completing and came across #274 .  This switch has been tested on macOS and Ubuntu 18.

Closes https://github.com/chromedp/chromedp/issues/274