### PR TITLE
fixed always waiting navigate action when context canceled

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -346,10 +346,14 @@ func (h *TargetHandler) Execute(ctxt context.Context, methodType string, params 
 	h.resrw.Unlock()
 
 	// queue message
-	h.qcmd <- &cdproto.Message{
+	select {
+	case h.qcmd <- &cdproto.Message{
 		ID:     id,
 		Method: cdproto.MethodType(methodType),
 		Params: paramsBuf,
+	}:
+	case <-ctxt.Done():
+		return ctxt.Err()
 	}
 
 	errch := make(chan error, 1)


### PR DESCRIPTION
I have been fixed issue that always waiting navigate action after context canceled.

This code to reproduce this issue.

thanks :D

```go
// create context
ctx, cancel := context.WithCancel(context.Background())

// create chrome instance
chrome, err := chromedp.New(ctx,
	chromedp.WithRunnerOptions(runner.Headless),
)
if err != nil {
	return err
}

cancel()

time.Sleep(time.Second)

fmt.Println("finished sleep")

// infinity wait
return chrome.Run(ctx, chromedp.Tasks{
	chromedp.Navigate("https://google.com"),
})
```