### PR TITLE
Generic code cleanup

### DIFF
--- a/allocate.go
+++ b/allocate.go
@@ -41,6 +41,7 @@ func NewAllocator(parent context.Context, opts ...AllocatorOption) (context.Cont
 	return ctx, cancel
 }
 
+// AllocatorOption is a allocator option.
 type AllocatorOption func(*Allocator)
 
 // WithExecAllocator returns an AllocatorOption which sets up an ExecAllocator.
@@ -59,6 +60,7 @@ func WithExecAllocator(opts ...ExecAllocatorOption) func(*Allocator) {
 	}
 }
 
+// ExecAllocatorOption is a exec allocator option.
 type ExecAllocatorOption func(*ExecAllocator)
 
 // ExecAllocator is an Allocator which starts new browser processes on the host
@@ -70,6 +72,7 @@ type ExecAllocator struct {
 	wg sync.WaitGroup
 }
 
+// Allocate satisfies the Allocator interface.
 func (p *ExecAllocator) Allocate(ctx context.Context) (*Browser, error) {
 	var args []string
 	for name, value := range p.initFlags {
@@ -146,6 +149,7 @@ func (p *ExecAllocator) Allocate(ctx context.Context) (*Browser, error) {
 	return browser, nil
 }
 
+// Wait satisfies the Allocator interface.
 func (p *ExecAllocator) Wait() {
 	p.wg.Wait()
 }
@@ -172,6 +176,7 @@ func findExecPath() string {
 	for _, path := range [...]string{
 		// Unix-like
 		"headless_shell",
+		"headless-shell",
 		"chromium",
 		"chromium-browser",
 		"google-chrome",

--- a/browser.go
+++ b/browser.go
@@ -12,11 +12,12 @@ import (
 	"log"
 	"sync/atomic"
 
+	"github.com/mailru/easyjson"
+
 	"github.com/chromedp/cdproto"
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/runtime"
 	"github.com/chromedp/cdproto/target"
-	"github.com/mailru/easyjson"
 )
 
 // Browser is the high-level Chrome DevTools Protocol browser manager, handling

--- a/eval.go
+++ b/eval.go
@@ -11,7 +11,7 @@ import (
 // Evaluate is an action to evaluate the Javascript expression, unmarshaling
 // the result of the script evaluation to res.
 //
-// When res is a type other than *[]byte, or **chromedp/cdp/runtime.RemoteObject,
+// When res is a type other than *[]byte, or **chromedp/cdproto/runtime.RemoteObject,
 // then the result of the script evaluation will be returned "by value" (ie,
 // JSON-encoded), and subsequently an attempt will be made to json.Unmarshal
 // the script result to res.

--- a/target.go
+++ b/target.go
@@ -227,6 +227,8 @@ func (t *Target) pageEvent(ev interface{}) {
 		return
 	case *page.EventLifecycleEvent:
 		return
+	case *page.EventNavigatedWithinDocument:
+		return
 
 	default:
 		t.errf("unhandled page event %T", ev)

--- a/util.go
+++ b/util.go
@@ -1,15 +1,8 @@
 package chromedp
 
 import (
-	"time"
-
 	"github.com/chromedp/cdproto"
 	"github.com/chromedp/cdproto/cdp"
-)
-
-const (
-	// DefaultCheckDuration is the default time to sleep between a check.
-	DefaultCheckDuration = 50 * time.Millisecond
 )
 
 // frameOp is a frame manipulation operation.


### PR DESCRIPTION
Adding some comments, removing unused items, and renaming handler.go to
target.go to reflect the internal type name changes.