### PR TITLE
Add options to gather stdout and stderr from browser

### DIFF
--- a/output_test.go
+++ b/output_test.go
@@ -1,0 +1,37 @@
+package chromedp
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestBrowserOutput(t *testing.T) {
+	t.Parallel()
+
+	buf := new(bytes.Buffer)
+	allocCtx, cancel := NewExecAllocator(context.Background(), append(allocOpts, CombinedOutput(buf))...)
+	defer cancel()
+
+	taskCtx, cancel := NewContext(allocCtx)
+	defer cancel()
+
+	if err := Run(taskCtx,
+		Navigate(testdataDir+"/image.html"),
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	output := buf.String()
+	found := false
+	prefix := "DevTools listening on"
+	for _, line := range strings.Split(output, "\n") {
+		if strings.HasPrefix(line, prefix) {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("Failed to find websocket string in browser output test")
+	}
+}


### PR DESCRIPTION
Attempt at adding feature in #347.  Exposes both stdout or stderr through an io.Writer. Should not affect users who do not use the added ExecAllocatorOptions `Stdout()` and `Stderr()`. 