### PR TITLE
add WaitNewTarget

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ language: go
 go:
   - 1.12.x
 
+env:
+  - GO111MODULE=on
+
 services:
   - docker
 

--- a/event_test.go
+++ b/event_test.go
@@ -157,18 +157,14 @@ func TestCloseDialog(t *testing.T) {
 	}
 }
 
-func TestClickNewTab(t *testing.T) {
+func TestWaitTarget(t *testing.T) {
 	t.Parallel()
 
 	ctx, cancel := testAllocate(t, "newtab.html")
 	defer cancel()
 
-	ch := make(chan target.ID, 1)
-	ListenTarget(ctx, func(ev interface{}) {
-		if ev, ok := ev.(*target.EventTargetCreated); ok &&
-			ev.TargetInfo.OpenerID != "" {
-			ch <- ev.TargetInfo.TargetID
-		}
+	ch := WaitNewTarget(ctx, func(info *target.Info) bool {
+		return info.URL != ""
 	})
 	if err := Run(ctx, Click("#new-tab", ByID)); err != nil {
 		t.Fatal(err)

--- a/example_test.go
+++ b/example_test.go
@@ -169,15 +169,9 @@ func ExampleClickNewTab() {
 	ts := httptest.NewServer(mux)
 	defer ts.Close()
 
-	lctx, cancel := context.WithCancel(ctx)
-	ch := make(chan target.ID, 1)
-	chromedp.ListenTarget(lctx, func(ev interface{}) {
-		if ev, ok := ev.(*target.EventTargetCreated); ok &&
-			// if OpenerID == "", this is the first tab.
-			ev.TargetInfo.OpenerID != "" {
-			ch <- ev.TargetInfo.TargetID
-			cancel()
-		}
+	// Grab the first spawned tab that isn't blank.
+	ch := chromedp.WaitNewTarget(ctx, func(info *target.Info) bool {
+		return info.URL != ""
 	})
 	if err := chromedp.Run(ctx,
 		chromedp.Navigate(ts.URL+"/first"),


### PR DESCRIPTION
Means that this common use case can be solved with just five lines of
simple Go code, as opposed to somewhat more complex dozen lines before.

WaitNewTarget also handles the edge cases nicely, such as listening on
both Created and InfoChanged events, ignoring attached targets, and
cancelling the listener once the function matches.

Fixes #371.