### PR TITLE
examples: add ExamplePrintToPDF

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ cdp-*.log
 cdp-*.txt
 
 /*.png
+/*.pdf
 
 coverage.out
 massif.out

--- a/example_test.go
+++ b/example_test.go
@@ -284,3 +284,27 @@ func ExampleEmulate() {
 		panic(err)
 	}
 }
+
+func ExamplePrintToPDF() {
+	ctx, cancel := chromedp.NewContext(context.Background())
+	defer cancel()
+
+	var buf []byte
+	if err := chromedp.Run(ctx,
+		chromedp.Navigate(`https://godoc.org/github.com/chromedp/chromedp`),
+		chromedp.ActionFunc(func(ctx context.Context) error {
+			var err error
+			buf, _, err = page.PrintToPDF().
+				WithDisplayHeaderFooter(false).
+				WithLandscape(true).
+				Do(ctx)
+			return err
+		}),
+	); err != nil {
+		panic(err)
+	}
+
+	if err := ioutil.WriteFile("page.pdf", buf, 0644); err != nil {
+		panic(err)
+	}
+}


### PR DESCRIPTION
Adds a quick example using PrintToPDF, which also show cases using the
cdproto package.