### PR TITLE
add chromedp.Env to add env vars for ExecAllocator

### DIFF
--- a/allocate_test.go
+++ b/allocate_test.go
@@ -290,3 +290,28 @@ func TestCombinedOutputError(t *testing.T) {
 		t.Fatalf("got %q, want %q", got, want)
 	}
 }
+
+func TestEnv(t *testing.T) {
+	t.Parallel()
+
+	tz := "Australia/Melbourne"
+	allocCtx, cancel := NewExecAllocator(context.Background(),
+		append([]ExecAllocatorOption{
+			Env("TZ=" + tz),
+		}, allocOpts...)...)
+	defer cancel()
+
+	ctx, cancel := NewContext(allocCtx)
+	defer cancel()
+
+	var ret string
+	if err := Run(ctx,
+		Evaluate(`Intl.DateTimeFormat().resolvedOptions().timeZone`, &ret),
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	if ret != tz {
+		t.Fatalf("got %s, want %s", ret, tz)
+	}
+}


### PR DESCRIPTION
use-cases include setting variables such as LANG, TZ or http_proxy
for specific chrome instances.

cc #190 https://github.com/GoogleChrome/chrome-launcher/issues/29