### PR TITLE
Change FullXPath generation for SVG nodes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/chromedp/chromedp
 go 1.11
 
 require (
-	github.com/chromedp/cdproto v0.0.0-20190704235924-3fd473b6d5d1
+	github.com/chromedp/cdproto v0.0.0-20190712010927-387ddc1113d4
 	github.com/gobwas/httphead v0.0.0-20180130184737-2c6c146eadee // indirect
 	github.com/gobwas/pool v0.2.0 // indirect
 	github.com/gobwas/ws v1.0.2

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/chromedp/cdproto v0.0.0-20190704235924-3fd473b6d5d1 h1:Zuz7nCHaZrnqoNDxIc+8katZjVTWdi/x/h0r4sW522g=
-github.com/chromedp/cdproto v0.0.0-20190704235924-3fd473b6d5d1/go.mod h1:0YChpVzuLJC5CPr+x3xkHN6Z8KOSXjNbL7qV8Wc4GW0=
+github.com/chromedp/cdproto v0.0.0-20190712010927-387ddc1113d4 h1:xe2O+jIdrblRgMr8wMHGcR9ZUQwfp3Vx105jmTpcpKU=
+github.com/chromedp/cdproto v0.0.0-20190712010927-387ddc1113d4/go.mod h1:0YChpVzuLJC5CPr+x3xkHN6Z8KOSXjNbL7qV8Wc4GW0=
 github.com/gobwas/httphead v0.0.0-20180130184737-2c6c146eadee h1:s+21KNqlpePfkah2I+gwHF8xmJWRjooY+5248k6m4A0=
 github.com/gobwas/httphead v0.0.0-20180130184737-2c6c146eadee/go.mod h1:L0fX3K22YWvt/FAX9NnzrNzcI4wNYi9Yku4O0LKYflo=
 github.com/gobwas/pool v0.2.0 h1:QEmUOlnSjWtnpRGHF3SauEiOsy82Cup83Vf2LcMlnc8=

--- a/js.go
+++ b/js.go
@@ -103,8 +103,8 @@ func cashX(flatten bool) func(*cdp.Node) string {
 func cashXNode(flatten bool) func(*cdp.Node) string {
 	return func(n *cdp.Node) string {
 		if flatten {
-			return fmt.Sprintf(`$x('%s/node()')[0]`, n.FullXPath())
+			return fmt.Sprintf(`$x(%q)[0]`, n.FullXPath()+"/node()")
 		}
-		return fmt.Sprintf(`$x('%s/node()')`, n.FullXPath())
+		return fmt.Sprintf(`$x(%q)`, n.FullXPath()+"/node()")
 	}
 }

--- a/testdata/svg.html
+++ b/testdata/svg.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+<body>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 400 90">
+  <text x="0" y="75" font-family="Aller" font-size="83" letter-spacing="1" id="brankas">
+    Brankas
+  </text>
+</svg>
+</body>
+</html>


### PR DESCRIPTION
Updates to latest cdproto, which generates SVG node names slightly
differently in FullXPath. Additionally adds a unit test to do a full
round-trip to the browser with the generated FullXPath to verify that
SVG elements are returned using the generated path.

Fixes #428.