### PR TITLE
Fix concurrency issues

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016-2018 Kenneth Shaw
+Copyright (c) 2016-2020 Kenneth Shaw
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/chromedp.go
+++ b/chromedp.go
@@ -281,7 +281,11 @@ func (c *Context) attachTarget(ctx context.Context, targetID target.ID) error {
 		return err
 	}
 
-	c.Target = c.Browser.newExecutorForTarget(targetID, sessionID)
+	c.Target, err = c.Browser.newExecutorForTarget(ctx, targetID, sessionID)
+	if err != nil {
+		return err
+	}
+
 	c.Target.listeners = append(c.Target.listeners, c.targetListeners...)
 	go c.Target.run(ctx)
 

--- a/conn.go
+++ b/conn.go
@@ -102,7 +102,11 @@ func (c *Conn) Read(_ context.Context, msg *cdproto.Message) error {
 	if c.dbgf != nil {
 		c.dbgf("<- %s", buf)
 	}
-	return rawUnmarshal(&c.decoder, buf, msg)
+
+	// unmarshal, reusing lexer
+	c.decoder = jlexer.Lexer{Data: buf}
+	msg.UnmarshalEasyJSON(&c.decoder)
+	return c.decoder.Error()
 }
 
 // Write writes a message.

--- a/util.go
+++ b/util.go
@@ -4,9 +4,6 @@ import (
 	"net"
 	"net/url"
 
-	easyjson "github.com/mailru/easyjson"
-	jlexer "github.com/mailru/easyjson/jlexer"
-
 	"github.com/chromedp/cdproto"
 	"github.com/chromedp/cdproto/cdp"
 )
@@ -30,23 +27,6 @@ func forceIP(urlstr string) string {
 	}
 	u.Host = net.JoinHostPort(addr.IP.String(), port)
 	return u.String()
-}
-
-func rawMarshal(v easyjson.Marshaler) easyjson.RawMessage {
-	if v == nil {
-		return nil
-	}
-	buf, err := easyjson.Marshal(v)
-	if err != nil {
-		panic(err)
-	}
-	return buf
-}
-
-func rawUnmarshal(lex *jlexer.Lexer, data []byte, v easyjson.Unmarshaler) error {
-	*lex = jlexer.Lexer{Data: data}
-	v.UnmarshalEasyJSON(lex)
-	return lex.Error()
 }
 
 func runListeners(list []cancelableListener, ev interface{}) []cancelableListener {


### PR DESCRIPTION
Intermittent timeouts on certain channel reads can occur, and not catch
when a context has been closed causing hangs and other potential issues.

This adds additional checks for when a context has been closed in a
first pass at fixing the fundamental issue.

Additionally, gets rid of the `raw{Marshal,Unmarshal}` calls, and
updates LICENSE.