### PR TITLE
docs: fix broken links to devices list

### DIFF
--- a/emulate.go
+++ b/emulate.go
@@ -82,7 +82,7 @@ func ResetViewport() EmulateAction {
 
 // Device is the shared interface for known device types.
 //
-// See: github.com/chromedp/chromedp/device for a set of off-the-shelf devices
+// See: https://github.com/chromedp/chromedp/blob/master/device/device.go for a set of off-the-shelf devices
 // and modes.
 type Device interface {
 	// Device returns the device info.
@@ -91,7 +91,7 @@ type Device interface {
 
 // Emulate is an action to emulate a specific device.
 //
-// See: github.com/chromedp/chromedp/device for a set of off-the-shelf devices
+// See: https://github.com/chromedp/chromedp/blob/master/device/device.go for a set of off-the-shelf devices
 // and modes.
 func Emulate(device Device) EmulateAction {
 	d := device.Device()


### PR DESCRIPTION
Fixes the broken links in the inline documentation for the list of off-the-shelf device types.