### PR TITLE
fix to gracefully close browser

### DIFF
--- a/browser.go
+++ b/browser.go
@@ -13,7 +13,6 @@ import (
 	easyjson "github.com/mailru/easyjson"
 
 	"github.com/chromedp/cdproto"
-	"github.com/chromedp/cdproto/browser"
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/target"
 )
@@ -140,10 +139,6 @@ func (b *Browser) newExecutorForTarget(ctx context.Context, targetID target.ID, 
 }
 
 func (b *Browser) Execute(ctx context.Context, method string, params easyjson.Marshaler, res easyjson.Unmarshaler) error {
-	if method == browser.CommandClose {
-		return fmt.Errorf("to close the browser, cancel its context or use chromedp.Cancel")
-	}
-
 	id := atomic.AddInt64(&b.next, 1)
 	lctx, cancel := context.WithCancel(ctx)
 	ch := make(chan *cdproto.Message, 1)

--- a/chromedp.go
+++ b/chromedp.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/chromedp/cdproto/browser"
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/css"
 	"github.com/chromedp/cdproto/dom"
@@ -183,12 +184,19 @@ func FromContext(ctx context.Context) *Context {
 //
 // Usually a "defer cancel()" will be enough for most use cases. This API is
 // useful if you want to catch underlying cancel errors, such as when a
-// temporary directory cannot be deleted.
+// temporary directory cannot be deleted.  Cancel will close the browser
+// instead of killing it.
 func Cancel(ctx context.Context) error {
 	c := FromContext(ctx)
 	if c == nil {
 		return ErrInvalidContext
 	}
+
+	err := c.Browser.Execute(ctx, browser.CommandClose, nil, nil)
+	if err != nil {
+		return err
+	}
+
 	c.cancel()
 	c.closedTarget.Wait()
 	// If we allocated, wait for the browser to stop.

--- a/chromedp.go
+++ b/chromedp.go
@@ -192,9 +192,11 @@ func Cancel(ctx context.Context) error {
 		return ErrInvalidContext
 	}
 
-	err := c.Browser.Execute(ctx, browser.CommandClose, nil, nil)
-	if err != nil {
-		return err
+	if len(FromContext(ctx).Browser.pages) == 1 {
+		err := c.Browser.Execute(ctx, browser.CommandClose, nil, nil)
+		if err != nil {
+			return err
+		}
 	}
 
 	c.cancel()


### PR DESCRIPTION
Modified chromedp.Cancel method to attempt to gracefully close browser instead of relying on os.Process.Kill that sends SIGKILL

Fixes "Chrome didn't shut down correctly" message on subsequent launch of browser after it is killed.

Code is borrowed from snippet posted by pmurley in question #472

