### PR TITLE
Add a GetBrowserPid option to browser.go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,10 @@ module github.com/chromedp/chromedp
 go 1.13
 
 require (
-	github.com/chromedp/cdproto v0.0.0-20191114225735-6626966fbae4
+	github.com/chromedp/cdproto v0.0.0-20200116234248-4da64dd111ac
 	github.com/gobwas/httphead v0.0.0-20180130184737-2c6c146eadee // indirect
 	github.com/gobwas/pool v0.2.0 // indirect
 	github.com/gobwas/ws v1.0.2
 	github.com/mailru/easyjson v0.7.0
-	golang.org/x/sys v0.0.0-20191113165036-4c7a9d0fe056 // indirect
+	golang.org/x/sys v0.0.0-20200116001909-b77594299b42 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/chromedp/cdproto v0.0.0-20191114225735-6626966fbae4 h1:QD3KxSJ59L2lxG6MXBjNHxiQO2RmxTQ3XcK+wO44WOg=
-github.com/chromedp/cdproto v0.0.0-20191114225735-6626966fbae4/go.mod h1:PfAWWKJqjlGFYJEidUM6aVIWPr0EpobeyVWEEmplX7g=
+github.com/chromedp/cdproto v0.0.0-20200116234248-4da64dd111ac h1:T7V5BXqnYd55Hj/g5uhDYumg9Fp3rMTS6bykYtTIFX4=
+github.com/chromedp/cdproto v0.0.0-20200116234248-4da64dd111ac/go.mod h1:PfAWWKJqjlGFYJEidUM6aVIWPr0EpobeyVWEEmplX7g=
 github.com/gobwas/httphead v0.0.0-20180130184737-2c6c146eadee h1:s+21KNqlpePfkah2I+gwHF8xmJWRjooY+5248k6m4A0=
 github.com/gobwas/httphead v0.0.0-20180130184737-2c6c146eadee/go.mod h1:L0fX3K22YWvt/FAX9NnzrNzcI4wNYi9Yku4O0LKYflo=
 github.com/gobwas/pool v0.2.0 h1:QEmUOlnSjWtnpRGHF3SauEiOsy82Cup83Vf2LcMlnc8=
@@ -10,5 +10,5 @@ github.com/knq/sysutil v0.0.0-20191005231841-15668db23d08 h1:V0an7KRw92wmJysvFvt
 github.com/knq/sysutil v0.0.0-20191005231841-15668db23d08/go.mod h1:dFWs1zEqDjFtnBXsd1vPOZaLsESovai349994nHx3e0=
 github.com/mailru/easyjson v0.7.0 h1:aizVhC/NAAcKWb+5QsU1iNOZb4Yws5UO2I+aIprQITM=
 github.com/mailru/easyjson v0.7.0/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
-golang.org/x/sys v0.0.0-20191113165036-4c7a9d0fe056 h1:dHtDnRWQtSx0Hjq9kvKFpBh9uPPKfQN70NZZmvssGwk=
-golang.org/x/sys v0.0.0-20191113165036-4c7a9d0fe056/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200116001909-b77594299b42 h1:vEOn+mP2zCOVzKckCZy6YsCtDblrpj/w7B9nxGNELpg=
+golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/input.go
+++ b/input.go
@@ -31,7 +31,7 @@ func MouseClickXY(x, y float64, opts ...MouseOption) MouseAction {
 			Type:       input.MousePressed,
 			X:          x,
 			Y:          y,
-			Button:     input.ButtonLeft,
+			Button:     input.Left,
 			ClickCount: 1,
 		}
 
@@ -90,11 +90,11 @@ type MouseOption = func(*input.DispatchMouseEventParams) *input.DispatchMouseEve
 
 // Button is a mouse action option to set the button to click from a string.
 func Button(btn string) MouseOption {
-	return ButtonType(input.ButtonType(btn))
+	return ButtonType(input.MouseButton(btn))
 }
 
 // ButtonType is a mouse action option to set the button to click.
-func ButtonType(button input.ButtonType) MouseOption {
+func ButtonType(button input.MouseButton) MouseOption {
 	return func(p *input.DispatchMouseEventParams) *input.DispatchMouseEventParams {
 		return p.WithButton(button)
 	}
@@ -103,25 +103,25 @@ func ButtonType(button input.ButtonType) MouseOption {
 // ButtonLeft is a mouse action option to set the button clicked as the left
 // mouse button.
 func ButtonLeft(p *input.DispatchMouseEventParams) *input.DispatchMouseEventParams {
-	return p.WithButton(input.ButtonLeft)
+	return p.WithButton(input.Left)
 }
 
 // ButtonMiddle is a mouse action option to set the button clicked as the middle
 // mouse button.
 func ButtonMiddle(p *input.DispatchMouseEventParams) *input.DispatchMouseEventParams {
-	return p.WithButton(input.ButtonMiddle)
+	return p.WithButton(input.Middle)
 }
 
 // ButtonRight is a mouse action option to set the button clicked as the right
 // mouse button.
 func ButtonRight(p *input.DispatchMouseEventParams) *input.DispatchMouseEventParams {
-	return p.WithButton(input.ButtonRight)
+	return p.WithButton(input.Right)
 }
 
 // ButtonNone is a mouse action option to set the button clicked as none (used
 // for mouse movements).
 func ButtonNone(p *input.DispatchMouseEventParams) *input.DispatchMouseEventParams {
-	return p.WithButton(input.ButtonNone)
+	return p.WithButton(input.None)
 }
 
 // ButtonModifiers is a mouse action option to add additional input modifiers

--- a/input_test.go
+++ b/input_test.go
@@ -73,14 +73,14 @@ func TestMouseClickNode(t *testing.T) {
 		opt      MouseOption
 		by       QueryOption
 	}{
-		{`button2`, "foo", ButtonType(input.ButtonNone), ByID},
-		{`button2`, "bar", ButtonType(input.ButtonLeft), ByID},
-		{`button2`, "bar-middle", ButtonType(input.ButtonMiddle), ByID},
+		{`button2`, "foo", ButtonType(input.None), ByID},
+		{`button2`, "bar", ButtonType(input.Left), ByID},
+		{`button2`, "bar-middle", ButtonType(input.Middle), ByID},
 		{`input3`, "foo", ButtonModifiers(input.ModifierNone), ByID},
-		{`input3`, "bar-right", ButtonType(input.ButtonRight), ByID},
+		{`input3`, "bar-right", ButtonType(input.Right), ByID},
 		{`input3`, "bar-right", Button("right"), ByID},
-		{`document.querySelector('#input3')`, "bar-right", ButtonType(input.ButtonRight), ByJSPath},
-		{`link`, "clicked", ButtonType(input.ButtonLeft), ByID},
+		{`document.querySelector('#input3')`, "bar-right", ButtonType(input.Right), ByJSPath},
+		{`link`, "clicked", ButtonType(input.Left), ByID},
 	}
 
 	for i, test := range tests {

--- a/query.go
+++ b/query.go
@@ -1111,7 +1111,7 @@ func Reset(sel interface{}, opts ...QueryOption) QueryAction {
 
 // ComputedStyle is an element query action that retrieves the computed style of the
 // first element node matching the selector.
-func ComputedStyle(sel interface{}, style *[]*css.ComputedProperty, opts ...QueryOption) QueryAction {
+func ComputedStyle(sel interface{}, style *[]*css.ComputedStyleProperty, opts ...QueryOption) QueryAction {
 	if style == nil {
 		panic("style cannot be nil")
 	}

--- a/query_test.go
+++ b/query_test.go
@@ -1168,7 +1168,7 @@ func TestComputedStyle(t *testing.T) {
 			ctx, cancel := testAllocate(t, "js.html")
 			defer cancel()
 
-			var styles []*css.ComputedProperty
+			var styles []*css.ComputedStyleProperty
 			if err := Run(ctx, ComputedStyle(test.sel, &styles, test.by)); err != nil {
 				t.Fatalf("got error: %v", err)
 			}

--- a/target.go
+++ b/target.go
@@ -244,6 +244,8 @@ func (t *Target) pageEvent(ev interface{}) {
 		return
 	case *page.EventWindowOpen:
 		return
+	case *page.EventDownloadWillBegin:
+		return
 
 	default:
 		t.errf("unhandled page event %T", ev)

--- a/util_test.go
+++ b/util_test.go
@@ -29,7 +29,7 @@ const dumpJS = `(function dump(n, prefix, indent, nodeIDs) {
 	var s = '';
 	if (typeof n.localName !== 'undefined') {
 		s = n.localName;
-	} 
+	}
 	if (s === '' && typeof n.nodeName !== 'undefined') {
 		s = n.nodeName;
 	}


### PR DESCRIPTION
This was a useful harmless tweak for my current project. The process PID can come in handy when there is talk about running a third party software against a remotely controlled browser.

I've re-used the error checking from Run, the closest-to-accurate error I could find for the browser not being valid is ErrInvalidTarget.

This is my first PR, if there's anything wrong I'd be happy to change it asap.

Note: the 19th of november commit "changed Run to return process pid" is no longer valid code and the current code is a recent pull of the latest chromedp version + the function added to browser.go
