### PR TITLE
Allow chromedp to attach to worker targets without error (#555)

### DIFF
--- a/chromedp.go
+++ b/chromedp.go
@@ -12,6 +12,7 @@ package chromedp
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -247,12 +248,14 @@ func (c *Context) newTarget(ctx context.Context) error {
 		// This new page might have already loaded its top-level frame
 		// already, in which case we wouldn't see the frameNavigated and
 		// documentUpdated events. Load them here.
-		tree, err := page.GetFrameTree().Do(cdp.WithExecutor(ctx, c.Target))
-		if err != nil {
-			return err
+		if !c.Target.isWorker {
+			tree, err := page.GetFrameTree().Do(cdp.WithExecutor(ctx, c.Target))
+			if err != nil {
+				return err
+			}
+			c.Target.cur = tree.Frame
+			c.Target.documentUpdated(ctx)
 		}
-		c.Target.cur = tree.Frame
-		c.Target.documentUpdated(ctx)
 		return nil
 	}
 	if !c.first {
@@ -313,19 +316,33 @@ func (c *Context) attachTarget(ctx context.Context, targetID target.ID) error {
 	c.Target.listeners = append(c.Target.listeners, c.targetListeners...)
 	go c.Target.run(ctx)
 
-	for _, action := range []Action{
-		// enable domains
+	if err := runtime.Enable().Do(cdp.WithExecutor(ctx, c.Target)); err != nil {
+		return err
+	}
+
+	res, _, err := runtime.Evaluate("self;").Do(cdp.WithExecutor(ctx, c.Target))
+	if err != nil {
+		return err
+	}
+	c.Target.isWorker = strings.Contains(res.ClassName, "WorkerGlobalScope")
+
+	// Enable available domains and discover targets.
+	actions := []Action{
 		log.Enable(),
 		runtime.Enable(),
-		inspector.Enable(),
-		page.Enable(),
-		dom.Enable(),
-		css.Enable(),
+	}
+	if !c.Target.isWorker {
+		actions = append(actions, []Action{
+			inspector.Enable(),
+			page.Enable(),
+			dom.Enable(),
+			css.Enable(),
+			target.SetDiscoverTargets(true),
+			target.SetAutoAttach(true, false).WithFlatten(true),
+		}...)
+	}
 
-		// enable target discovery
-		target.SetDiscoverTargets(true),
-		target.SetAutoAttach(true, false).WithFlatten(true),
-	} {
+	for _, action := range actions {
 		if err := action.Do(cdp.WithExecutor(ctx, c.Target)); err != nil {
 			return fmt.Errorf("unable to execute %T: %v", action, err)
 		}

--- a/chromedp.go
+++ b/chromedp.go
@@ -316,10 +316,12 @@ func (c *Context) attachTarget(ctx context.Context, targetID target.ID) error {
 	c.Target.listeners = append(c.Target.listeners, c.targetListeners...)
 	go c.Target.run(ctx)
 
+	// Check if this is a worker target. We cannot use Target.getTargetInfo or
+	// Target.getTargets in a worker, so we check if `self` refers to a
+	// WorkerGlobalScope or ServiceWorkerGlobalScope.
 	if err := runtime.Enable().Do(cdp.WithExecutor(ctx, c.Target)); err != nil {
 		return err
 	}
-
 	res, _, err := runtime.Evaluate("self;").Do(cdp.WithExecutor(ctx, c.Target))
 	if err != nil {
 		return err

--- a/chromedp.go
+++ b/chromedp.go
@@ -335,6 +335,7 @@ func (c *Context) attachTarget(ctx context.Context, targetID target.ID) error {
 	actions := []Action{
 		log.Enable(),
 	}
+	// These actions are not available on a worker target.
 	if !c.Target.isWorker {
 		actions = append(actions, []Action{
 			inspector.Enable(),

--- a/chromedp_test.go
+++ b/chromedp_test.go
@@ -731,13 +731,13 @@ func TestAttachingToWorkers(t *testing.T) {
 			mux.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "text/html")
 				io.WriteString(w, fmt.Sprintf(`
-			<html>
-				<body>
-					<script>
-						%s
-					</script>
-				</body>
-			</html>`, tc.pageJS))
+					<html>
+						<body>
+							<script>
+								%s
+							</script>
+						</body>
+					</html>`, tc.pageJS))
 			}))
 			mux.Handle("/worker.js", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "text/javascript")

--- a/target.go
+++ b/target.go
@@ -35,6 +35,9 @@ type Target struct {
 
 	// logging funcs
 	logf, errf func(string, ...interface{})
+
+	// Indicates if the target is a worker target.
+	isWorker bool
 }
 
 func (t *Target) run(ctx context.Context) {


### PR DESCRIPTION
The way we tell if a new target is a web worker or a service worker is by using `Runtime.evaluate` and the fact that `self` in workers will refer to either a `[Service]WorkerGlobalScope`.

Fixes [issue #555](https://github.com/chromedp/chromedp/issues/555)