### PR TITLE
fix: docs for ListenTraget and ListenBrowser were swapped

### DIFF
--- a/chromedp.go
+++ b/chromedp.go
@@ -455,8 +455,9 @@ type cancelableListener struct {
 }
 
 // ListenBrowser adds a function which will be called whenever a browser event
-// is received on the chromedp context. Cancelling ctx stops the listener from
-// receiving any more events.
+// is received on the chromedp context. Note that this only includes browser
+// events; command responses and target events are not included. Cancelling ctx
+// stops the listener from receiving any more events.
 //
 // Note that the function is called synchronously when handling events. The
 // function should avoid blocking at all costs. For example, any Actions must be
@@ -477,9 +478,8 @@ func ListenBrowser(ctx context.Context, fn func(ev interface{})) {
 }
 
 // ListenTarget adds a function which will be called whenever a target event is
-// received on the chromedp context. Note that this only includes browser
-// events; command responses and target events are not included. Cancelling ctx
-// stops the listener from receiving any more events.
+// received on the chromedp context. Cancelling ctx stops the listener from
+// receiving any more events.
 //
 // Note that the function is called synchronously when handling events. The
 // function should avoid blocking at all costs. For example, any Actions must be


### PR DESCRIPTION
I _think_ that the sentence

> Note that this only includes browser events; command responses and target events are not included.

was incorrectly added to the documentation for `ListenTarget`, while it refers to `ListenBrowser`.

If I am wrong, then the names for these two functions are a bit confusing :-)

* Function ListenTarget has been added in https://github.com/chromedp/chromedp/commit/39c308a94a7d95a4297791821f6c0df6edf7af52
* Function ListenBrowser has been added in https://github.com/chromedp/chromedp/commit/50c80f91be4ddefee7e881df4613d3ac3fc1aa3a