### PR TITLE
Use %ProgramFiles% and %LocalAppData% to locate chrome.exe more critically

### DIFF
--- a/allocate.go
+++ b/allocate.go
@@ -336,10 +336,10 @@ func findExecPath() string {
 
 		// Windows
 		"chrome",
-		"chrome.exe", // in case PATHEXT is misconfigured
-		`C:\Program Files (x86)\Google\Chrome\Application\chrome.exe`,
-		`C:\Program Files\Google\Chrome\Application\chrome.exe`,
-		filepath.Join(os.Getenv("USERPROFILE"), `AppData\Local\Google\Chrome\Application\chrome.exe`),
+		"chrome.exe", // In case PATHEXT is misconfigured
+		filepath.Join(os.Getenv("ProgramFiles"), `\Google\Chrome\Application\chrome.exe`),      // In case the `Program Files` folder is not under C: drive
+		filepath.Join(os.Getenv("ProgramFiles(x86)"), `\Google\Chrome\Application\chrome.exe`), // In case the `Program Files (x86)` folder is not under C: drive
+		filepath.Join(os.Getenv("LocalAppData"), `\Google\Chrome\Application\chrome.exe`),      // In case the `Local` folder is not under `%UserProfile%\AppData`
 
 		// Mac
 		"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",

--- a/allocate.go
+++ b/allocate.go
@@ -337,9 +337,12 @@ func findExecPath() string {
 		// Windows
 		"chrome",
 		"chrome.exe", // In case PATHEXT is misconfigured
-		filepath.Join(os.Getenv("ProgramFiles"), `\Google\Chrome\Application\chrome.exe`),      // In case the `Program Files` folder is not under C: drive
-		filepath.Join(os.Getenv("ProgramFiles(x86)"), `\Google\Chrome\Application\chrome.exe`), // In case the `Program Files (x86)` folder is not under C: drive
-		filepath.Join(os.Getenv("LocalAppData"), `\Google\Chrome\Application\chrome.exe`),      // In case the `Local` folder is not under `%UserProfile%\AppData`
+		filepath.Join(os.Getenv("ProgramFiles"), `\Google\Chrome\Application\chrome.exe`),              // In case the `Program Files` folder is not under C: drive
+		`C:\Program Files\Google\Chrome\Application\chrome.exe`,                                        // In case %ProgramFiles% is not set
+		filepath.Join(os.Getenv("ProgramFiles(x86)"), `\Google\Chrome\Application\chrome.exe`),         // In case the `Program Files (x86)` folder is not under C: drive
+		`C:\Program Files(x86)\Google\Chrome\Application\chrome.exe`,                                   // In case %ProgramFiles(x86)% is not set
+		filepath.Join(os.Getenv("LocalAppData"), `\Google\Chrome\Application\chrome.exe`),              // In case the `Local` folder is not under `%UserProfile%\AppData`
+		filepath.Join(os.Getenv("UserProfile"), `\AppData\Local\Google\Chrome\Application\chrome.exe`), // In case %LocalAppData% is not set
 
 		// Mac
 		"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",


### PR DESCRIPTION
Because `Program Files` folder and `Program Files (x86)` folder are not always under C: drive, 
and `Local` folder is not always under `%UserProfile%\AppData`.