### PR TITLE
add a QueryOption to run a query from a specified node

### DIFF
--- a/testdata/nested.html
+++ b/testdata/nested.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html>
+<head>
+  <title>page with nested elements</title>
+</head>
+<body>
+  <p class="content">body root content</p>
+  <div id="parent1">
+    <div id="child1">
+      <p class="content">child1 content</p>
+    </div>
+  </div>
+  <div id="parent2">
+    <div id="child2">
+      <p class="content">child2 content</p>
+      <p class="content">child2 content</p>
+    </div>
+  </div>
+  <div id="empty">
+  </div>
+</body>
+</html>


### PR DESCRIPTION
Called FromNode, it means that we can run a query rooted at a specific
node, instead of the default which is the root node of the document.

Fixes #463.