### PR TITLE
Enable filtering visible nodes as an option

### DIFF
--- a/query.go
+++ b/query.go
@@ -34,6 +34,7 @@ type Selector struct {
 	by       func(context.Context, *cdp.Node) ([]cdp.NodeID, error)
 	wait     func(context.Context, *cdp.Frame, ...cdp.NodeID) ([]*cdp.Node, error)
 	after    func(context.Context, ...*cdp.Node) error
+	filter   func(context.Context, *cdp.Node) (bool, error)
 	raw      bool
 }
 
@@ -194,6 +195,24 @@ func (s *Selector) Do(ctx context.Context) error {
 		if nodes == nil || err != nil {
 			continue
 		}
+
+		if s.filter != nil {
+			for i, node := range nodes {
+				is, err := s.filter(ctx, node)
+				if err != nil {
+					continue
+				}
+
+				if !is {
+					nodes = append(nodes[0:i], nodes[i+1:]...)
+				}
+
+				if len(nodes) < s.exp {
+					continue
+				}
+			}
+		}
+
 		if s.after != nil {
 			if err := s.after(ctx, nodes...); err != nil {
 				return err
@@ -274,6 +293,12 @@ func FromNode(node *cdp.Node) QueryOption {
 func ByFunc(f func(context.Context, *cdp.Node) ([]cdp.NodeID, error)) QueryOption {
 	return func(s *Selector) {
 		s.by = f
+	}
+}
+
+func FilterFunc(f func(context.Context, *cdp.Node) (bool, error)) QueryOption {
+	return func(s *Selector) {
+		s.filter = f
 	}
 }
 
@@ -416,23 +441,11 @@ func NodeReady(s *Selector) {
 // nodes have been sent by the browser and are visible.
 func NodeVisible(s *Selector) {
 	WaitFunc(s.waitReady(func(ctx context.Context, n *cdp.Node) error {
-		// check box model
-		_, err := dom.GetBoxModel().WithNodeID(n.NodeID).Do(ctx)
-		if err != nil {
-			if isCouldNotComputeBoxModelError(err) {
-				return ErrNotVisible
-			}
-
-			return err
-		}
-
-		// check visibility
-		var res bool
-		err = EvaluateAsDevTools(snippet(visibleJS, cashX(true), s, n), &res).Do(ctx)
+		visible, err := isNodeVisible(ctx, n, s)
 		if err != nil {
 			return err
 		}
-		if !res {
+		if !visible {
 			return ErrNotVisible
 		}
 		return nil
@@ -443,27 +456,22 @@ func NodeVisible(s *Selector) {
 // nodes have been sent by the browser and are not visible.
 func NodeNotVisible(s *Selector) {
 	WaitFunc(s.waitReady(func(ctx context.Context, n *cdp.Node) error {
-		// check box model
-		_, err := dom.GetBoxModel().WithNodeID(n.NodeID).Do(ctx)
-		if err != nil {
-			if isCouldNotComputeBoxModelError(err) {
-				return nil
-			}
-
-			return err
-		}
-
-		// check visibility
-		var res bool
-		err = EvaluateAsDevTools(snippet(visibleJS, cashX(true), s, n), &res).Do(ctx)
+		visible, err := isNodeVisible(ctx, n, s)
 		if err != nil {
 			return err
 		}
-		if res {
+		if visible {
 			return ErrVisible
 		}
 		return nil
 	}))(s)
+}
+
+func FilterVisible(s *Selector) {
+	FilterFunc(func(ctx context.Context, n *cdp.Node) (b bool, err error) {
+		b, e := isNodeVisible(ctx, n, s)
+		return b,e
+	})(s)
 }
 
 // NodeEnabled is an element query option to wait until all queried element

--- a/query_test.go
+++ b/query_test.go
@@ -87,6 +87,39 @@ func TestWaitNotVisible(t *testing.T) {
 	}
 }
 
+
+func TestFilterVisible(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := testAllocate(t, "js.html")
+	defer cancel()
+
+	var nodeIDs []cdp.NodeID
+	if err := Run(ctx, NodeIDs("#input2", &nodeIDs, ByID, FilterVisible)); err != nil {
+		t.Fatalf("got error: %v", err)
+	}
+	if len(nodeIDs) != 1 {
+		t.Errorf("expected to have exactly 1 node id: got %d", len(nodeIDs))
+	}
+
+	var value string
+	if err := Run(ctx,
+		Click("#button2", ByID),
+		WaitNotVisible("#input2", ByID),
+		Value(nodeIDs, &value, ByNodeID),
+	); err != nil {
+		t.Fatalf("got error: %v", err)
+	}
+
+	if err := Run(ctx, NodeIDs("#input2", &nodeIDs, ByID, FilterVisible, AtLeast(0))); err != nil {
+		t.Fatalf("got error: %v", err)
+	}
+	if len(nodeIDs) != 0 {
+		t.Errorf("expected to have exactly 0 node id: got %d", len(nodeIDs))
+	}
+}
+
+
 func TestWaitEnabled(t *testing.T) {
 	t.Parallel()
 

--- a/util.go
+++ b/util.go
@@ -4,7 +4,6 @@ import (
 	"net"
 	"net/url"
 
-	"github.com/chromedp/cdproto"
 	"github.com/chromedp/cdproto/cdp"
 )
 
@@ -318,9 +317,3 @@ func removeNode(n []*cdp.Node, id cdp.NodeID) []*cdp.Node {
 	return append(n[:i], n[i+1:]...)
 }
 
-// isCouldNotComputeBoxModelError unwraps err as a MessageError and determines
-// if it is a compute box model error.
-func isCouldNotComputeBoxModelError(err error) bool {
-	e, ok := err.(*cdproto.Error)
-	return ok && e.Code == -32000 && e.Message == "Could not compute box model."
-}

--- a/visibility.go
+++ b/visibility.go
@@ -1,0 +1,38 @@
+package chromedp
+
+import (
+	"context"
+	"github.com/chromedp/cdproto"
+	"github.com/chromedp/cdproto/cdp"
+	"github.com/chromedp/cdproto/dom"
+)
+
+// isCouldNotComputeBoxModelError unwraps err as a MessageError and determines
+// if it is a compute box model error.
+func isCouldNotComputeBoxModelError(err error) bool {
+	e, ok := err.(*cdproto.Error)
+	return ok && e.Code == -32000 && e.Message == "Could not compute box model."
+}
+
+func isNodeVisible(ctx context.Context, n *cdp.Node, s *Selector) (bool, error) {
+	// check box model
+	_, err := dom.GetBoxModel().WithNodeID(n.NodeID).Do(ctx)
+	if err != nil {
+		if isCouldNotComputeBoxModelError(err) {
+			return false, nil
+		}
+
+		return false, err
+	}
+
+	// check visibility
+	var res bool
+	err = EvaluateAsDevTools(snippet(visibleJS, cashX(true), s, n), &res).Do(ctx)
+	if err != nil {
+		return false, err
+	}
+	if !res {
+		return false, nil
+	}
+	return true, nil
+}


### PR DESCRIPTION
Currently, we cannot tell ChromeDP to select all visible nodes without
waiting for them.

If one calls
```
NodeIDs(selector, WaitVisible, AtLeast(0))
```

chromeDP selects all nodes with the selector and then wait for them to be visible.
This might hang if it never happens and the node keeps being hidden.

With this PR, we can do
```
NodeIDs(selector, FilterVisible, AtLeast(0))
```

However, the following will still hang, since the waiting is done before the filtering;
as we need the nodes to be at least ready to filter them. I think it's OK,
but it might be confusing.

```
NodeIDs(selector, WaitVisible, FilterVisible, AtLeast(0))
```