### PR TITLE
Added ability to authentication proxies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,7 @@ cdp-*.txt
 /chromedp.test
 /chromedp.test.exe
 
+.idea
+
 /*.png
 /*.pdf

--- a/chromedp.go
+++ b/chromedp.go
@@ -11,15 +11,18 @@ package chromedp
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/chromedp/cdproto"
 	"github.com/chromedp/cdproto/browser"
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/css"
 	"github.com/chromedp/cdproto/dom"
+	"github.com/chromedp/cdproto/fetch"
 	"github.com/chromedp/cdproto/inspector"
 	"github.com/chromedp/cdproto/log"
 	"github.com/chromedp/cdproto/network"
@@ -383,6 +386,60 @@ func (c *Context) attachTarget(ctx context.Context, targetID target.ID) error {
 		}
 	}
 	return nil
+}
+
+// Authentication proxy
+func Authentication(login string, password string) Tasks {
+	return Tasks{
+		fetch.Enable().WithPatterns([]*fetch.RequestPattern{{"*", "", ""}}).WithHandleAuthRequests(true),
+		ActionFunc(func(ctx context.Context) error {
+			if login != "" && password != "" {
+				c := FromContext(ctx)
+				if c == nil || c.Allocator == nil || c.cancel == nil {
+					return ErrInvalidContext
+				}
+				id := 1000
+				ListenTarget(ctx, func(ev interface{}) {
+					switch ev := ev.(type) {
+
+					case *fetch.EventAuthRequired:
+						buf, _ := json.Marshal(map[string]interface{}{
+							"requestId": ev.RequestID.String(),
+							"authChallengeResponse": map[string]string{
+								"response": "ProvideCredentials",
+								"username": login,
+								"password": password,
+							},
+						})
+						cmd := &cdproto.Message{
+							ID:        int64(id + 1),
+							SessionID: c.Target.SessionID,
+							Method:    cdproto.MethodType("Fetch.continueWithAuth"),
+							Params:    buf,
+						}
+						err := c.Browser.conn.Write(ctx, cmd)
+						if err != nil {
+							panic(err)
+						}
+
+					case *fetch.EventRequestPaused:
+						buf, _ := json.Marshal(map[string]string{"requestId":ev.RequestID.String()})
+						cmd := &cdproto.Message{
+							ID:        int64(id + 1),
+							SessionID: c.Target.SessionID,
+							Method:    cdproto.MethodType("Fetch.continueRequest"),
+							Params:    buf,
+						}
+						err := c.Browser.conn.Write(ctx, cmd)
+						if err != nil {
+							panic(err)
+						}
+					}
+				})
+			}
+			return nil
+		}),
+	}
 }
 
 // ContextOption is a context option.


### PR DESCRIPTION
Resolved a problem with authentication proxies. 
I used websocket connection without ready-made functions because there has delay. For this to work, you need to send a request without delay and queues.
Maybe it's seeming like hard code but it works. If you have any ideas for better realization please let me know)