### PR TITLE
sets c.allocated to nil on cancels

### DIFF
--- a/chromedp.go
+++ b/chromedp.go
@@ -168,6 +168,7 @@ func NewContext(parent context.Context, opts ...ContextOption) (context.Context,
 		// If we allocated, wait for the browser to stop.
 		if c.allocated != nil {
 			<-c.allocated
+			c.allocated = nil
 		}
 	}
 	return ctx, cancelWait
@@ -215,6 +216,7 @@ func Cancel(ctx context.Context) error {
 	if c.allocated != nil {
 		select {
 		case <-c.allocated:
+			c.allocated = nil
 		case <-ctx.Done():
 		}
 	}

--- a/chromedp_test.go
+++ b/chromedp_test.go
@@ -1055,3 +1055,15 @@ func TestRunResponse_noResponse(t *testing.T) {
 		}
 	}
 }
+
+func TestCancelBlock(t *testing.T) {
+	ctx, cancel := NewContext(context.Background())
+	cancel()
+
+	if err := Cancel(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	cancel()
+	cancel()
+}


### PR DESCRIPTION
In Cancel, if ctx.Done's chan is read first then it's not a problem, but
if we read the allocated chan then any follow up cancel func calls will
block on their allocated chan reads.

Fixes by setting c.allocated to nil if the chan was read.