### PR TITLE
support wait and after funcs with iframes

### DIFF
--- a/browser.go
+++ b/browser.go
@@ -15,6 +15,7 @@ import (
 	"github.com/chromedp/cdproto"
 	"github.com/chromedp/cdproto/browser"
 	"github.com/chromedp/cdproto/cdp"
+	"github.com/chromedp/cdproto/runtime"
 	"github.com/chromedp/cdproto/target"
 )
 
@@ -132,6 +133,7 @@ func (b *Browser) newExecutorForTarget(ctx context.Context, targetID target.ID, 
 
 		messageQueue: make(chan *cdproto.Message, 1024),
 		frames:       make(map[cdp.FrameID]*cdp.Frame),
+		execContexts: make(map[cdp.FrameID]runtime.ExecutionContextID),
 		cur:          cdp.FrameID(targetID),
 
 		logf: b.logf,

--- a/js.go
+++ b/js.go
@@ -104,9 +104,9 @@ func snippet(js string, f func(n *cdp.Node) string, sel interface{}, n *cdp.Node
 func cashX(flatten bool) func(*cdp.Node) string {
 	return func(n *cdp.Node) string {
 		if flatten {
-			return fmt.Sprintf(`$x(%q)[0]`, n.FullXPath())
+			return fmt.Sprintf(`$x(%q)[0]`, n.PartialXPath())
 		}
-		return fmt.Sprintf(`$x(%q)`, n.FullXPath())
+		return fmt.Sprintf(`$x(%q)`, n.PartialXPath())
 	}
 }
 
@@ -114,8 +114,8 @@ func cashX(flatten bool) func(*cdp.Node) string {
 func cashXNode(flatten bool) func(*cdp.Node) string {
 	return func(n *cdp.Node) string {
 		if flatten {
-			return fmt.Sprintf(`$x(%q)[0]`, n.FullXPath()+"/node()")
+			return fmt.Sprintf(`$x(%q)[0]`, n.PartialXPath()+"/node()")
 		}
-		return fmt.Sprintf(`$x(%q)`, n.FullXPath()+"/node()")
+		return fmt.Sprintf(`$x(%q)`, n.PartialXPath()+"/node()")
 	}
 }

--- a/nav_test.go
+++ b/nav_test.go
@@ -280,11 +280,15 @@ func TestQueryIframe(t *testing.T) {
 	if err := Run(ctx, Nodes(`iframe`, &iframes, ByQuery)); err != nil {
 		t.Fatal(err)
 	}
+	var gotFoo string
 	if err := Run(ctx,
-		// TODO: WaitVisible hangs here.
-		WaitReady(`#form`, ByID, FromNode(iframes[0])),
+		WaitVisible(`#form`, ByQuery, FromNode(iframes[0])),
+		Text("#foo", &gotFoo, ByQuery, FromNode(iframes[0])),
 	); err != nil {
 		t.Fatal(err)
+	}
+	if want := "insert"; gotFoo != want {
+		t.Fatalf("wanted %q, got %q", want, gotFoo)
 	}
 }
 

--- a/target.go
+++ b/target.go
@@ -2,6 +2,7 @@ package chromedp
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"sync"
 	"sync/atomic"
@@ -12,6 +13,7 @@ import (
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/dom"
 	"github.com/chromedp/cdproto/page"
+	"github.com/chromedp/cdproto/runtime"
 	"github.com/chromedp/cdproto/target"
 )
 
@@ -29,7 +31,8 @@ type Target struct {
 	// frameMu protects both frames and cur.
 	frameMu sync.RWMutex
 	// frames is the set of encountered frames.
-	frames map[cdp.FrameID]*cdp.Frame
+	frames       map[cdp.FrameID]*cdp.Frame
+	execContexts map[cdp.FrameID]runtime.ExecutionContextID
 	// cur is the current top level frame.
 	cur cdp.FrameID
 
@@ -46,7 +49,10 @@ func (t *Target) run(ctx context.Context) {
 		value  interface{}
 	}
 	// syncEventQueue is used to handle events synchronously within Target.
-	syncEventQueue := make(chan eventValue, 1024)
+	// TODO: If this queue gets full, the goroutine below could get stuck on
+	// a send, and response callbacks would never run, resulting in a
+	// deadlock. Can we fix this without potentially using lots of memory?
+	syncEventQueue := make(chan eventValue, 4096)
 
 	// This goroutine receives events from the browser, calls listeners, and
 	// then passes the events onto the main goroutine for the target handler
@@ -80,7 +86,7 @@ func (t *Target) run(ctx context.Context) {
 				t.listenersMu.Unlock()
 
 				switch msg.Method.Domain() {
-				case "Page", "DOM":
+				case "Runtime", "Page", "DOM":
 					select {
 					case <-ctx.Done():
 						return
@@ -97,6 +103,8 @@ func (t *Target) run(ctx context.Context) {
 			return
 		case ev := <-syncEventQueue:
 			switch ev.method.Domain() {
+			case "Runtime":
+				t.runtimeEvent(ev.value)
 			case "Page":
 				t.pageEvent(ev.value)
 			case "DOM":
@@ -163,6 +171,42 @@ func (t *Target) Execute(ctx context.Context, method string, params easyjson.Mar
 		}
 	}
 	return nil
+}
+
+// runtimeEvent handles incoming runtime events.
+func (t *Target) runtimeEvent(ev interface{}) {
+	switch ev := ev.(type) {
+	case *runtime.EventExecutionContextCreated:
+		var aux struct {
+			FrameID cdp.FrameID
+		}
+		if len(ev.Context.AuxData) == 0 {
+			break
+		}
+		if err := json.Unmarshal(ev.Context.AuxData, &aux); err != nil {
+			t.errf("could not decode executionContextCreated auxData %q: %v", ev.Context.AuxData, err)
+			break
+		}
+		if aux.FrameID != "" {
+			t.frameMu.Lock()
+			t.execContexts[aux.FrameID] = ev.Context.ID
+			t.frameMu.Unlock()
+		}
+	case *runtime.EventExecutionContextDestroyed:
+		t.frameMu.Lock()
+		for frameID, ctxID := range t.execContexts {
+			if ctxID == ev.ExecutionContextID {
+				delete(t.execContexts, frameID)
+			}
+		}
+		t.frameMu.Unlock()
+	case *runtime.EventExecutionContextsCleared:
+		t.frameMu.Lock()
+		for frameID := range t.execContexts {
+			delete(t.execContexts, frameID)
+		}
+		t.frameMu.Unlock()
+	}
 }
 
 // documentUpdated handles the document updated event, retrieving the document


### PR DESCRIPTION
This makes use of Chrome's runtime execution context ID. In other words,
what javascript context we run our Evaluate commands in.

What we were doing before was locating a node's javascript object by
using its full XPath via the $x function. This worked fine for the most
part, but it did not work with iframes. Javascript isn't meant to have
access to the content of nested frames like that at all times, as it
would be a security concern.

Instead, in Chrome's console tab one can see a nifty "context" dropdown,
which defaults to "top", and allows you to run javascript in the context
of other frames in the page such as iframes.

We make use of that feature here, via the WithContextID option in the
Evaluate command. Each Frame has an ExecutionContextID, so we keep track
of those via runtime events and a map.

Then, when we use element objects via javascript, we make sure to use
the right execution context ID, depending on what frame we want to work
with. By default, that will be the top-level frame, as before; but if
the user specified FromNode, then that node's frame will be used
instead.

TestQueryIframe contains a sample of how this can work, and here is a
short sample:

        var iframes []*cdp.Node
        if err := chromedp.Run(ctx, chromedp.Nodes(`iframe`, &iframes, chromedp.ByQuery)); err != nil {
		handle(err)
	}

        var text string
        if err := chromedp.Run(ctx,
                chromedp.Text("#some_id", &text, chromedp.ByQuery, chromedp.FromNode(iframes[0])),
        ); err != nil {
                handle(err)
        }
	fmt.Println(text)

Fixes #72.