### PR TITLE
Add func MutateSelector to allow user code to mutate a selectors "sel…

### DIFF
--- a/query.go
+++ b/query.go
@@ -37,6 +37,18 @@ type Selector struct {
 	raw      bool
 }
 
+// MutateSelector allows to mutate the Selectors sel string.
+func MutateSelector(s *Selector, m func(strSel string) string) *Selector {
+	strSel, isString := s.sel.(string)
+	if !isString {
+		panic("mutation of non-string mutator is not supported")
+	}
+
+	s.sel = m(strSel)
+
+	return s
+}
+
 // Query is a query action that queries the browser for specific element
 // node(s) matching the criteria.
 //

--- a/query_test.go
+++ b/query_test.go
@@ -1518,3 +1518,20 @@ func TestFromNode(t *testing.T) {
 		})
 	}
 }
+
+func TestMutateSelector(t *testing.T) {
+	s := &Selector{
+		sel: "test",
+	}
+
+	m := func(s string) string {
+		return s + "-123"
+	}
+
+	got := MutateSelector(s, m).sel
+	want := "test-123"
+
+	if want != got {
+		t.Fatalf("want: %v, got: %v", want, got)
+	}
+}


### PR DESCRIPTION
Here's a implementation that enables implementing custom queries which resolve #689 

The implementation is minimally invasive by adding a exposed func instead of exposing Selector data directly or adding an exposed method to the Selector type.