### PR TITLE
ScrollIntoView json unmarshal error fix

### DIFF
--- a/query.go
+++ b/query.go
@@ -1215,7 +1215,7 @@ func ScrollIntoView(sel interface{}, opts ...QueryOption) QueryAction {
 			return fmt.Errorf("selector %q did not return any nodes", sel)
 		}
 
-		var pos []int
+		var pos []float64
 		err := evalInCtx(ctx, execCtx, snippet(scrollIntoViewJS, cashX(true), sel, nodes[0]), &pos)
 		if err != nil {
 			return err


### PR DESCRIPTION
Right now function `ScrollIntoView` tries to unmarshall `window.scrollX` and `window.scrollY`
https://github.com/chromedp/chromedp/blob/72bf375971cb5c2ac69aa48b8e1d4e7cef25982b/js.go#L43
to
https://github.com/chromedp/chromedp/blob/446edaac636801f6752ff834fa5ef672d4e0d607/query.go#L1218
Which occasionally results in errors like this:
`json: cannot unmarshal number 17592.619140625 into Go value of type int` 

But according to [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollY):

> In practice, the returned value is a double-precision floating-point value