### PR TITLE
Do not set pdeathsig to the process on AWS Lambda

### DIFF
--- a/allocate_linux.go
+++ b/allocate_linux.go
@@ -3,11 +3,18 @@
 package chromedp
 
 import (
+	"os"
 	"os/exec"
 	"syscall"
 )
 
 func allocateCmdOptions(cmd *exec.Cmd) {
+	_, isLambda := os.LookupEnv("LAMBDA_TASK_ROOT")
+	if isLambda {
+		// do nothing on AWS Lambda
+		return
+	}
+
 	if cmd.SysProcAttr == nil {
 		cmd.SysProcAttr = new(syscall.SysProcAttr)
 	}


### PR DESCRIPTION
Since it's not supported by the AWS Lambda runtime

Fixes #562
