### PR TITLE
Fixed comment about websocket timeout in allocate.go

### DIFF
--- a/allocate.go
+++ b/allocate.go
@@ -215,7 +215,7 @@ func (a *ExecAllocator) Allocate(ctx context.Context, opts ...BrowserOption) (*B
 
 	// Chrome will sometimes fail to print the websocket, or run for a long
 	// time, without properly exiting. To avoid blocking forever in those
-	// cases, give up after ten seconds.
+	// cases, give up after twenty seconds.
 	const wsURLReadTimeout = 20 * time.Second
 
 	var wsURL string


### PR DESCRIPTION
This is just a small fix of a comment that i have stumbled on way too often to ignore it's out-of-date'ness.