### PR TITLE
Fir compilation error.

### DIFF
--- a/chromedp.go
+++ b/chromedp.go
@@ -154,10 +154,7 @@ func NewContext(parent context.Context, opts ...ContextOption) (context.Context,
 		}
 		if id := c.Target.TargetID; id != "" {
 			action := target.CloseTarget(id)
-			if ok, err := action.Do(cdp.WithExecutor(ctx, c.Browser)); c.cancelErr == nil {
-				if !ok && err == nil {
-					err = fmt.Errorf("could not close target %q", id)
-				}
+			if err := action.Do(cdp.WithExecutor(ctx, c.Browser)); c.cancelErr == nil {
 				c.cancelErr = err
 			}
 		}


### PR DESCRIPTION
The chromedp dosen't build:
../github.com/chromedp/chromedp/chromedp.go:157:15: assignment mismatch: 2 variables but 1 values

The Do function in Action interface returns only Error, there is no other variable returned.

Tested on commit: d31ce4baad38d7c602a7acb36a2037f4d310eb59
Go version: go version go1.11.6 linux/amd64
Operating system: 
`
Distributor ID:	Debian
Description:	Debian GNU/Linux 10 (buster)
Release:	10
Codename:	buster
`
