### PR TITLE
Expose os.Process from the Browser

### DIFF
--- a/browser.go
+++ b/browser.go
@@ -119,6 +119,18 @@ func NewBrowser(ctx context.Context, urlstr string, opts ...BrowserOption) (*Bro
 	return b, nil
 }
 
+// Process returns the process object of the browser.
+// It could be nil when the browser is allocated with RemoteAllocator.
+// It can be used to control the memory consumed by the browser process.
+//
+// Example:
+//     if process := chromedp.FromContext(ctx).Browser.Process(); process != nil {
+//         fmt.Printf("Browser PID: %v", process.Pid)
+//     }
+func (b *Browser) Process() *os.Process {
+	return b.process
+}
+
 func (b *Browser) newExecutorForTarget(ctx context.Context, targetID target.ID, sessionID target.SessionID) (*Target, error) {
 	if targetID == "" {
 		return nil, errors.New("empty target ID")
@@ -308,15 +320,6 @@ func (b *Browser) run(ctx context.Context) {
 			return // to avoid "write: broken pipe" errors
 		}
 	}
-}
-
-// Process returns the Chrome process object
-// Example:
-//     if process := chromedp.FromContext(ctx).Browser.Process(); process != nil {
-//         fmt.Printf("Chrome PID: %v", process.Pid)
-//     }
-func (b *Browser) Process() *os.Process {
-	return b.process
 }
 
 // BrowserOption is a browser option.

--- a/browser.go
+++ b/browser.go
@@ -310,7 +310,7 @@ func (b *Browser) run(ctx context.Context) {
 	}
 }
 
-// Pid returning browser PID
+// Pid returns the browser process ID
 func (b *Browser) Pid() int {
 	return b.process.Pid
 }

--- a/browser.go
+++ b/browser.go
@@ -120,6 +120,7 @@ func NewBrowser(ctx context.Context, urlstr string, opts ...BrowserOption) (*Bro
 }
 
 // Process returns the process object of the browser.
+//
 // It could be nil when the browser is allocated with RemoteAllocator.
 // It can be used to control the memory consumed by the browser process.
 //

--- a/browser.go
+++ b/browser.go
@@ -310,9 +310,13 @@ func (b *Browser) run(ctx context.Context) {
 	}
 }
 
-// PID returns the browser process ID
-func (b *Browser) PID() int {
-	return b.process.Pid
+// Process returns the Chrome process object
+// Example:
+//     if process := chromedp.FromContext(ctx).Browser.Process(); process != nil {
+//         fmt.Printf("Chrome PID: %v", process.Pid)
+//     }
+func (b *Browser) Process() *os.Process {
+	return b.process
 }
 
 // BrowserOption is a browser option.

--- a/browser.go
+++ b/browser.go
@@ -122,7 +122,8 @@ func NewBrowser(ctx context.Context, urlstr string, opts ...BrowserOption) (*Bro
 // Process returns the process object of the browser.
 //
 // It could be nil when the browser is allocated with RemoteAllocator.
-// It can be used to control the memory consumed by the browser process.
+// It could be useful for a monitoring system to collect process metrics of the browser process.
+// (see https://pkg.go.dev/github.com/prometheus/client_golang/prometheus#NewProcessCollector for an example)
 //
 // Example:
 //     if process := chromedp.FromContext(ctx).Browser.Process(); process != nil {

--- a/browser.go
+++ b/browser.go
@@ -310,8 +310,8 @@ func (b *Browser) run(ctx context.Context) {
 	}
 }
 
-// Pid returns the browser process ID
-func (b *Browser) Pid() int {
+// PID returns the browser process ID
+func (b *Browser) PID() int {
 	return b.process.Pid
 }
 

--- a/browser.go
+++ b/browser.go
@@ -310,6 +310,11 @@ func (b *Browser) run(ctx context.Context) {
 	}
 }
 
+// Pid returning browser PID
+func (b *Browser) Pid() int {
+	return b.process.Pid
+}
+
 // BrowserOption is a browser option.
 type BrowserOption = func(*Browser)
 


### PR DESCRIPTION
Hi,
I've see #566, but we need a pid to control memory for all Chrome processes. We use this to export prometheus metrics with the consumed memory of sessions, for displaying on the Grafana dashboard.

Usage:
```
chromedp.FromContext(ctx).Browser.Process()
```