### PR TITLE
add poll action to imitate puppeteer's page.waitForFunction

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -45,4 +45,7 @@ const (
 
 	// ErrInvalidContext is the invalid context error.
 	ErrInvalidContext Error = "invalid context"
+
+	// ErrPollingTimeout is the error that the timeout reached before the pageFunction returns a truthy value.
+	ErrPollingTimeout Error = "waiting for function failed: timeout"
 )

--- a/js.go
+++ b/js.go
@@ -87,6 +87,89 @@ const (
 	visibleJS = `(function(a) {
 		return Boolean( a.offsetWidth || a.offsetHeight || a.getClientRects().length );
 	})(%s)`
+
+	// waitForPredicatePageFunction is a javascript snippet that runs the polling in the
+	// browser. It's copied from puppeteer. See
+	// https://github.com/puppeteer/puppeteer/blob/669f04a7a6e96cc8353a8cb152898edbc25e7c15/src/common/DOMWorld.ts#L870-L944
+	// It's modified to make mutation polling respect timeout even when there is not DOM mutation.
+	waitForPredicatePageFunction = `async function waitForPredicatePageFunction(predicateBody, polling, timeout, ...args) {
+		const predicate = new Function('...args', predicateBody);
+		let timedOut = false;
+		if (timeout)
+			setTimeout(() => (timedOut = true), timeout);
+		if (polling === 'raf')
+			return await pollRaf();
+		if (polling === 'mutation')
+			return await pollMutation();
+		if (typeof polling === 'number')
+			return await pollInterval(polling);
+		/**
+		 * @returns {!Promise<*>}
+		 */
+		async function pollMutation() {
+			const success = await predicate(...args);
+			if (success)
+				return Promise.resolve(success);
+			let fulfill;
+			const result = new Promise((x) => (fulfill = x));
+			const observer = new MutationObserver(async () => {
+				if (timedOut) {
+					observer.disconnect();
+					fulfill();
+				}
+				const success = await predicate(...args);
+				if (success) {
+					observer.disconnect();
+					fulfill(success);
+				}
+			});
+			observer.observe(document, {
+				childList: true,
+				subtree: true,
+				attributes: true,
+			});
+			if (timeout)
+				setTimeout(() => {
+					observer.disconnect();
+					fulfill();
+				}, timeout);
+			return result;
+		}
+		async function pollRaf() {
+			let fulfill;
+			const result = new Promise((x) => (fulfill = x));
+			await onRaf();
+			return result;
+			async function onRaf() {
+				if (timedOut) {
+					fulfill();
+					return;
+				}
+				const success = await predicate(...args);
+				if (success)
+					fulfill(success);
+				else
+					requestAnimationFrame(onRaf);
+			}
+		}
+		async function pollInterval(pollInterval) {
+			let fulfill;
+			const result = new Promise((x) => (fulfill = x));
+			await onTimeout();
+			return result;
+			async function onTimeout() {
+				if (timedOut) {
+					fulfill();
+					return;
+				}
+				const success = await predicate(...args);
+				if (success)
+					fulfill(success);
+				else
+					setTimeout(onTimeout, pollInterval);
+			}
+		}
+	}`
 )
 
 // snippet builds a Javascript expression snippet.

--- a/poll.go
+++ b/poll.go
@@ -1,0 +1,215 @@
+package chromedp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/chromedp/cdproto/cdp"
+	"github.com/chromedp/cdproto/runtime"
+)
+
+// PollAction are actions that will wait for a general Javascript predicate.
+//
+// See Poll for details on building poll tasks.
+type PollAction Action
+
+// pollTask holds information pertaining to an poll task.
+//
+// See Poll for details on building poll tasks.
+type pollTask struct {
+	frame     *cdp.Node // the frame to evaluate the predicate, defaults to the root page
+	predicate string
+	polling   string        // the polling mode, defaults to "raf" (triggered by requestAnimationFrame)
+	interval  time.Duration // the interval when the poll is triggered by a timer
+	timeout   time.Duration // the poll timeout, defaults to 30 seconds
+	args      []interface{}
+	res       interface{}
+}
+
+// Do executes the poll task in the browser,
+// until the predicate either returns truthy value or the timeout happens.
+func (p *pollTask) Do(ctx context.Context) error {
+	t := cdp.ExecutorFromContext(ctx).(*Target)
+	if t == nil {
+		return ErrInvalidTarget
+	}
+	var frameID cdp.FrameID
+	if p.frame == nil {
+		frameID = t.cur
+	} else {
+		frameID = t.enclosingFrame(p.frame)
+	}
+	t.frameMu.RLock()
+	execCtx := t.execContexts[frameID]
+	t.frameMu.RUnlock()
+
+	ea := &errAppender{args: make([]*runtime.CallArgument, 0, len(p.args)+3)}
+	ea.append(p.predicate)
+	if p.interval > 0 {
+		ea.append(p.interval.Milliseconds())
+	} else {
+		ea.append(p.polling)
+	}
+	ea.append(p.timeout.Milliseconds())
+	for _, arg := range p.args {
+		ea.append(arg)
+	}
+	if ea.err != nil {
+		return ea.err
+	}
+
+	v, exp, err := runtime.CallFunctionOn(waitForPredicatePageFunction).
+		WithExecutionContextID(execCtx).
+		WithReturnByValue(false).
+		WithAwaitPromise(true).
+		WithUserGesture(true).
+		WithArguments(ea.args).
+		Do(ctx)
+	if err != nil {
+		return err
+	}
+	if exp != nil {
+		return exp
+	}
+
+	if v.Type == "undefined" {
+		return ErrPollingTimeout
+	}
+
+	// it's okay to discard the result.
+	if p.res == nil {
+		return nil
+	}
+
+	switch x := p.res.(type) {
+	case **runtime.RemoteObject:
+		*x = v
+		return nil
+
+	case *[]byte:
+		*x = v.Value
+		return nil
+	default:
+		return json.Unmarshal(v.Value, p.res)
+	}
+}
+
+// Poll is a poll action that will wait for a general Javascript predicate.
+// It builds the predicate from a Javascript expression.
+//
+// This is a copy of puppeteer's page.waitForFunction.
+// see https://github.com/puppeteer/puppeteer/blob/v8.0.0/docs/api.md#pagewaitforfunctionpagefunction-options-args.
+// It's named Poll intentionally to avoid messing up with the Wait* query actions.
+// The behavior is not guaranteed to be compatible.
+// For example, our implementation makes the poll task not survive from a navigation,
+// and an error is raised in this case (see unit test TestPoll/NotSurviveNavigation).
+//
+// Polling Options
+//
+// The default polling mode is "raf", to constantly execute pageFunction in requestAnimationFrame callback.
+// This is the tightest polling mode which is suitable to observe styling changes.
+// The WithPollingInterval option makes it to poll the predicate with a specified interval.
+// The WithPollingMutation option makes it to poll the predicate on every DOM mutation.
+//
+// The WithPollingTimeout option specifies the maximum time to wait for the predicate returns truthy value.
+// It defaults to 30 seconds. Pass 0 to disable timeout.
+//
+// The WithPollingInFrame option specifies the frame in which to evaluate the predicate.
+// If not specified, it will be evaluated in the root page of the current tab.
+//
+// The WithPollingArgs option provides extra arguments to pass to the predicate.
+// Only apply this option when the predicate is built from a function.
+// See PollFunction.
+func Poll(expression string, res interface{}, opts ...PollOption) PollAction {
+	predicate := fmt.Sprintf(`return (%s);`, expression)
+	return poll(predicate, res, opts...)
+}
+
+// PollFunction is a poll action that will wait for a general Javascript predicate.
+// It builds the predicate from a Javascript function.
+//
+// See Poll for details on building poll tasks.
+func PollFunction(pageFunction string, res interface{}, opts ...PollOption) PollAction {
+	predicate := fmt.Sprintf(`return (%s)(...args);`, pageFunction)
+
+	return poll(predicate, res, opts...)
+}
+
+func poll(predicate string, res interface{}, opts ...PollOption) PollAction {
+	p := &pollTask{
+		predicate: predicate,
+		polling:   "raf",
+		timeout:   30 * time.Second,
+		res:       res,
+	}
+
+	// apply options
+	for _, o := range opts {
+		o(p)
+	}
+	return p
+}
+
+// PollOption is an poll task option.
+type PollOption = func(task *pollTask)
+
+// WithPollingInterval makes it to poll the predicate with the specified interval.
+func WithPollingInterval(interval time.Duration) PollOption {
+	return func(w *pollTask) {
+		w.polling = ""
+		w.interval = interval
+	}
+}
+
+// WithPollingMutation makes it to poll the predicate on every DOM mutation.
+func WithPollingMutation() PollOption {
+	return func(w *pollTask) {
+		w.polling = "mutation"
+		w.interval = 0
+	}
+}
+
+// WithPollingTimeout specifies the maximum time to wait for the predicate returns truthy value.
+// It defaults to 30 seconds. Pass 0 to disable timeout.
+func WithPollingTimeout(timeout time.Duration) PollOption {
+	return func(w *pollTask) {
+		w.timeout = timeout
+	}
+}
+
+// WithPollingInFrame specifies the frame in which to evaluate the predicate.
+// If not specified, it will be evaluated in the root page of the current tab.
+func WithPollingInFrame(frame *cdp.Node) PollOption {
+	return func(w *pollTask) {
+		w.frame = frame
+	}
+}
+
+// WithPollingArgs provides extra arguments to pass to the predicate.
+func WithPollingArgs(args ...interface{}) PollOption {
+	return func(w *pollTask) {
+		w.args = args
+	}
+}
+
+// errAppender is to help accumulating the arguments and simplifying error checks.
+//
+// see https://blog.golang.org/errors-are-values
+type errAppender struct {
+	args []*runtime.CallArgument
+	err  error
+}
+
+// append method calls the json.Marshal method to marshal the value and appends it to the slice.
+// It records the first error for future reference.
+// As soon as an error occurs, the append method becomes a no-op but the error value is saved.
+func (ea *errAppender) append(v interface{}) {
+	if ea.err != nil {
+		return
+	}
+	var b []byte
+	b, ea.err = json.Marshal(v)
+	ea.args = append(ea.args, &runtime.CallArgument{Value: b})
+}

--- a/poll_test.go
+++ b/poll_test.go
@@ -1,0 +1,197 @@
+package chromedp
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/chromedp/cdproto"
+	"github.com/chromedp/cdproto/cdp"
+	"github.com/chromedp/cdproto/runtime"
+)
+
+func TestPoll(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := testAllocate(t, "")
+	defer cancel()
+
+	tests := []struct {
+		name         string
+		js           string
+		isFunction   bool
+		options      []PollOption
+		hash         string
+		wantErr      error
+		wantMinDelay time.Duration
+	}{
+		{
+			name:       "ExpressionPredicate",
+			js:         "globalThis.__FOO === 1",
+			isFunction: false,
+		},
+		{
+			name:       "LambdaCallPredicate",
+			js:         "(() => globalThis.__FOO === 1)()",
+			isFunction: false,
+		},
+		{
+			name:       "MultilinePredicate",
+			js:         "\n(() => globalThis.__FOO === 1)()\n",
+			isFunction: false,
+		},
+		{
+			name:       "FunctionPredicate",
+			js:         "function foo(){return globalThis.__FOO === 1;}",
+			isFunction: true,
+		},
+		{
+			name:       "LambdaAsFunction",
+			js:         "() => globalThis.__FOO === 1",
+			isFunction: true,
+		},
+		{
+			name:       "Timeout",
+			js:         "false",
+			isFunction: false,
+			options:    []PollOption{WithPollingTimeout(10 * time.Millisecond)},
+			wantErr:    ErrPollingTimeout,
+		},
+		{
+			name: "ResolvedRightBeforeExecutionContextDisposal",
+			js: `()=>{
+				if (window.location.hash === '#reload'){
+					window.location.replace(window.location.href.substring(0, 0 - '#reload'.length));
+				}
+				return true;
+			}`,
+			isFunction: true,
+			hash:       "#reload",
+		},
+		{
+			name: "NotSurviveNavigation",
+			js: `()=>{
+				if (window.location.hash === '#navigate'){
+					window.location.replace(window.location.href.substring(0, 0 - '#navigate'.length));
+				} else {
+					return globalThis.__FOO === 1;;
+				}
+			}`,
+			isFunction: true,
+			hash:       "#navigate",
+			wantErr:    &cdproto.Error{Code: -32000, Message: "Execution context was destroyed."},
+		},
+		{
+			name:         "PollingInterval",
+			js:           "globalThis.__FOO === 1",
+			isFunction:   false,
+			options:      []PollOption{WithPollingInterval(100 * time.Millisecond)},
+			hash:         "#100",
+			wantMinDelay: 50 * time.Millisecond,
+		},
+		{
+			name:         "PollingMutation",
+			js:           "globalThis.__FOO === 1",
+			isFunction:   false,
+			options:      []PollOption{WithPollingMutation(), WithPollingTimeout(200 * time.Millisecond)},
+			hash:         "#mutation",
+			wantMinDelay: 50 * time.Millisecond,
+		},
+		{
+			name:       "TimeoutWithoutMutation ",
+			js:         "globalThis.__FOO === 1",
+			isFunction: false,
+			options:    []PollOption{WithPollingMutation(), WithPollingTimeout(100 * time.Millisecond)},
+			wantErr:    ErrPollingTimeout,
+		},
+		{
+			name:       "TimeoutBeforeMutation ",
+			js:         "globalThis.__FOO === 1",
+			isFunction: false,
+			options:    []PollOption{WithPollingMutation(), WithPollingTimeout(50 * time.Millisecond)},
+			hash:       "#mutation",
+			wantErr:    ErrPollingTimeout,
+		},
+		{
+			name:       "ExtraArgs",
+			js:         "(a1, a2) => a1 === 1 && a2 === 'str'",
+			isFunction: true,
+			options:    []PollOption{WithPollingArgs(1, "str")},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			tabCtx, tabCancel := NewContext(ctx)
+			defer tabCancel()
+			var action PollAction
+			var res bool
+			if test.isFunction {
+				action = PollFunction(test.js, &res, test.options...)
+			} else {
+				action = Poll(test.js, &res, test.options...)
+			}
+
+			startTime := time.Now()
+			err := Run(tabCtx,
+				Navigate(testdataDir+"/poll.html"+test.hash),
+				action,
+			)
+			if !reflect.DeepEqual(test.wantErr, err) {
+				t.Fatalf("want error to be %q, got %q", test.wantErr, err)
+			}
+			if test.wantErr == nil && !res {
+				t.Fatal("it should resolve with truthy result")
+			}
+			if test.wantMinDelay != 0 {
+				delay := time.Since(startTime)
+				if delay < test.wantMinDelay {
+					t.Fatalf("want min delay to be %v, got %v", test.wantMinDelay, delay)
+				}
+			}
+		})
+	}
+}
+
+func TestPollFrame(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := testAllocate(t, "frameset.html")
+	defer cancel()
+
+	var res string
+	var frames []*cdp.Node
+	if err := Run(ctx,
+		Nodes(`frame[src="child1.html"]`, &frames, ByQuery),
+		ActionFunc(func(ctx context.Context) error {
+			return Poll(`document.querySelector("#child1>p").textContent`, &res, WithPollingInFrame(frames[0])).Do(ctx)
+		}),
+	); err != nil {
+		t.Fatalf("got error: %v", err)
+	}
+
+	want := "child one"
+	if res != want {
+		t.Fatalf("want result to be %q, got %q", want, res)
+	}
+}
+
+func TestPollRemoteObject(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := testAllocate(t, "poll.html")
+	defer cancel()
+
+	expression := `window`
+
+	var res *runtime.RemoteObject
+	if err := Run(ctx, Poll(expression, &res, WithPollingTimeout(10*time.Millisecond))); err != nil {
+		t.Fatalf("got error: %v", err)
+	}
+
+	wantClassName := "Window"
+	if res.ClassName != wantClassName {
+		t.Fatalf("want class name of remote object to be %q, got %q", wantClassName, res.ClassName)
+	}
+}

--- a/testdata/poll.html
+++ b/testdata/poll.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html>
+<head>
+    <title>chromedp poll test page</title>
+    <script>
+        let timeout = 10;
+        let hash = window.location.hash;
+        if (hash !== "") {
+            hash = hash.substr(1);
+            num = parseInt(hash);
+            if (!isNaN(num)) {
+                timeout = num;
+            }
+        }
+        setTimeout(() => globalThis.__FOO = 1, timeout);
+
+        if (hash === "mutation") {
+            setTimeout(() => {
+                document.body.appendChild(document.createElement('div'))
+            }, 100);
+        }
+    </script>
+</head>
+<body>
+</body>
+</html>


### PR DESCRIPTION
To fix issue #680.

The new action is called `Poll` to avoid messing up with the `Wait*` query actions.

Here is the documentation for [Puppeteer's page.waitForFunction](https://github.com/puppeteer/puppeteer/blob/v8.0.0/docs/api.md#pagewaitforfunctionpagefunction-options-args).