### PR TITLE
make tests run in Github Actions pass

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,4 +32,4 @@ jobs:
     - name: Build
       run: go test -c -vet=off
     - name: Test
-      run: docker run --rm --volume=$PWD:/chromedp --entrypoint=/chromedp/chromedp.test --workdir=/chromedp --env=PATH=/headless-shell chromedp/headless-shell:latest -test.v
+      run: docker run --rm --volume=$PWD:/chromedp --entrypoint=/chromedp/chromedp.test --workdir=/chromedp --env=PATH=/headless-shell --env=HEADLESS_SHELL=1 chromedp/headless-shell:latest -test.v

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Test
-      run: go test -v ./...
+      run: TMPDIR=$RUNNER_TEMP go test -v ./...
   test-headless-shell:
     runs-on: ubuntu-latest
     steps:

--- a/allocate_test.go
+++ b/allocate_test.go
@@ -244,7 +244,10 @@ func TestExecAllocatorMissingWebsocketAddr(t *testing.T) {
 	ctx, cancel := NewContext(allocCtx)
 	defer cancel()
 
-	want := regexp.MustCompile(`failed to start:\n.*Invalid devtools`)
+	// set the "s" flag to let "." match "\n"
+	// in Github Actions, the error text could be:
+	// "chrome failed to start:\n/bin/bash: /etc/profile.d/env_vars.sh: Permission denied\nmkdir: cannot create directory ‘/run/user/1001’: Permission denied\n[0321/081807.491906:ERROR:headless_shell.cc(720)] Invalid devtools server address\n"
+	want := regexp.MustCompile(`(?s)failed to start:\n.*Invalid devtools`)
 	got := fmt.Sprintf("%v", Run(ctx))
 	if !want.MatchString(got) {
 		t.Fatalf("want error to match %q, got %q", want, got)

--- a/input_test.go
+++ b/input_test.go
@@ -2,6 +2,7 @@ package chromedp
 
 import (
 	"fmt"
+	"os"
 	"strconv"
 	"testing"
 
@@ -173,6 +174,10 @@ func TestMouseClickOffscreenNode(t *testing.T) {
 }
 
 func TestKeyEvent(t *testing.T) {
+	if os.Getenv("HEADLESS_SHELL") != "" {
+		t.Skip(`Skip in headless-shell due to "Check failed: IsSupportedClipboardBuffer(buffer)"`)
+	}
+
 	t.Parallel()
 
 	tests := []struct {
@@ -207,6 +212,8 @@ func TestKeyEvent(t *testing.T) {
 			if err := Run(ctx,
 				Focus(test.sel, test.by),
 				KeyEvent(kb.Home),
+				// "KeyEvent(kb.End, KeyModifiers(input.ModifierShift))" crash headless-shell with this error:
+				// [...:FATAL:headless_clipboard.cc(296)] Check failed: IsSupportedClipboardBuffer(buffer)
 				KeyEvent(kb.End, KeyModifiers(input.ModifierShift)),
 				KeyEvent(test.exp),
 			); err != nil {
@@ -226,6 +233,10 @@ func TestKeyEvent(t *testing.T) {
 }
 
 func TestKeyEventNode(t *testing.T) {
+	if os.Getenv("HEADLESS_SHELL") != "" {
+		t.Skip(`Skip in headless-shell due to "Check failed: IsSupportedClipboardBuffer(buffer)"`)
+	}
+
 	t.Parallel()
 
 	tests := []struct {
@@ -260,6 +271,8 @@ func TestKeyEventNode(t *testing.T) {
 			var value string
 			if err := Run(ctx,
 				KeyEventNode(nodes[0], kb.Home),
+				// "KeyEventNode(nodes[0], kb.End, KeyModifiers(input.ModifierShift))" crash headless-shell with this error:
+				// [...:FATAL:headless_clipboard.cc(296)] Check failed: IsSupportedClipboardBuffer(buffer)
 				KeyEventNode(nodes[0], kb.End, KeyModifiers(input.ModifierShift)),
 				KeyEventNode(nodes[0], test.exp),
 				Value(test.sel, &value, test.by),


### PR DESCRIPTION
1. it can not write to the `/tmp` directory. We should use `RUNNER_TEMP` as the temp directory.
2. `TestExecAllocatorMissingWebsocketAddr` got different error in Github Actions:
    local:
    ```
    chrome failed to start:
    [0321/235654.258252:ERROR:headless_shell.cc(720)] Invalid devtools server address
    ```
    github actions:
    ```
    chrome failed to start:
    /bin/bash: /etc/profile.d/env_vars.sh: Permission denied
    mkdir: cannot create directory ‘/run/user/1001’: Permission denied
    [0321/081807.491906:ERROR:headless_shell.cc(720)] Invalid devtools server address
    ```
3. `TestKeyEvent` and `TestKeyEventNode` will crash `headless-shell`, so skip them until [the issue](https://bugs.chromium.org/p/chromium/issues/detail?id=1170634&q=IsSupportedClipboardBuffer&can=2) has been fixed. 