### PR TITLE
Fix some of the issues in the Poll action

### DIFF
--- a/poll_test.go
+++ b/poll_test.go
@@ -89,26 +89,42 @@ func TestPoll(t *testing.T) {
 			delay:  50 * time.Millisecond,
 		},
 		{
-			name:   "PollingMutation",
-			js:     "globalThis.__FOO === 1",
-			isFunc: false,
+			name: "PollingMutation",
+			js: `() => {
+				if (globalThis.__Mutation === 1){
+					return true;
+				} else {
+					globalThis.__Mutation = 1;
+					setTimeout(() => {
+						document.body.appendChild(document.createElement('div'))
+					}, 100);
+				}
+			}`,
+			isFunc: true,
 			opts:   []PollOption{WithPollingMutation(), WithPollingTimeout(200 * time.Millisecond)},
-			hash:   "#mutation",
 			delay:  50 * time.Millisecond,
 		},
 		{
 			name:   "TimeoutWithoutMutation",
-			js:     "globalThis.__FOO === 1",
+			js:     "globalThis.__Mutation === 1",
 			isFunc: false,
 			opts:   []PollOption{WithPollingMutation(), WithPollingTimeout(100 * time.Millisecond)},
 			err:    ErrPollingTimeout.Error(),
 		},
 		{
-			name:   "TimeoutBeforeMutation",
-			js:     "globalThis.__FOO === 1",
-			isFunc: false,
+			name: "TimeoutBeforeMutation",
+			js: `() => {
+				if (globalThis.__Mutation === 1){
+					return true;
+				} else {
+					globalThis.__Mutation = 1;
+					setTimeout(() => {
+						document.body.appendChild(document.createElement('div'))
+					}, 100);
+				}
+			}`,
+			isFunc: true,
 			opts:   []PollOption{WithPollingMutation(), WithPollingTimeout(50 * time.Millisecond)},
-			hash:   "#mutation",
 			err:    ErrPollingTimeout.Error(),
 		},
 		{

--- a/poll_test.go
+++ b/poll_test.go
@@ -151,15 +151,19 @@ func TestPoll(t *testing.T) {
 				Navigate(testdataDir+"/poll.html"+test.hash),
 				action,
 			)
-			if test.err != "" {
+			if test.err == "" {
+				if err != nil {
+					t.Fatalf("got error: %v", err)
+				} else if !res {
+					t.Fatalf("got no error, but res is not true")
+				}
+
+			} else {
 				if err == nil {
 					t.Fatalf("expected err to be %q, got: %v", test.err, err)
 				} else if test.err != err.Error() {
 					t.Fatalf("want error to be %v, got: %v", test.err, err)
 				}
-			}
-			if test.err == "" && !res {
-				t.Fatalf("got no error, but res is not true")
 			}
 			if test.delay != 0 {
 				delay := time.Since(startTime)

--- a/testdata/poll.html
+++ b/testdata/poll.html
@@ -13,12 +13,6 @@
             }
         }
         setTimeout(() => globalThis.__FOO = 1, timeout);
-
-        if (hash === "mutation") {
-            setTimeout(() => {
-                document.body.appendChild(document.createElement('div'))
-            }, 100);
-        }
     </script>
 </head>
 <body>


### PR DESCRIPTION
The Poll action failed the tests very often. I have found two issues in the implementation:

1. it does not wait for the `runtime.ExecutionContextID` to be available.
2. the tests for the `WithPollingMutation()` option is unreliable.

This PR fixes those issues.

@kenshaw Sorry to ping you directly, but can you take some time to review this changes? The buggy implementation has already been merged into the master branch, I hope that the issues can be addressed asap. Thank you very much!