### PR TITLE
fix: update chromedp disable-features TranslateUI to Translate

### DIFF
--- a/allocate.go
+++ b/allocate.go
@@ -65,7 +65,7 @@ var DefaultExecAllocatorOptions = [...]ExecAllocatorOption{
 	Flag("disable-default-apps", true),
 	Flag("disable-dev-shm-usage", true),
 	Flag("disable-extensions", true),
-	Flag("disable-features", "site-per-process,TranslateUI,BlinkGenPropertyTrees"),
+	Flag("disable-features", "site-per-process,Translate,BlinkGenPropertyTrees"),
 	Flag("disable-hang-monitor", true),
 	Flag("disable-ipc-flooding-protection", true),
 	Flag("disable-popup-blocking", true),


### PR DESCRIPTION
### ISSUE:

[Since September 2020 the TranslateUI feature has been renamed to Translate.](https://chromium-review.googlesource.com/c/chromium/src/+/2404484) 
As such the DefaultExecAllocatorOptions will not prevent the translate popup to appear in UI.

### CHANGES:

- [x] Changed `TranslateUI` to `Translate`