### PR TITLE
call submit/reset from prototype in case they are masked by form controls

### DIFF
--- a/js.go
+++ b/js.go
@@ -47,10 +47,10 @@ const (
 	// submit function, returning true or false if the call was successful.
 	submitJS = `(function(a) {
 		if (a.nodeName === 'FORM') {
-			a.submit();
+			HTMLFormElement.prototype.submit.call(a);
 			return true;
 		} else if (a.form !== null) {
-			a.form.submit();
+			HTMLFormElement.prototype.submit.call(a.form);
 			return true;
 		}
 		return false;
@@ -60,10 +60,10 @@ const (
 	// reset function, returning true or false if the call was successful.
 	resetJS = `(function(a) {
 		if (a.nodeName === 'FORM') {
-			a.reset();
+			HTMLFormElement.prototype.reset.call(a);
 			return true;
 		} else if (a.form !== null) {
-			a.form.reset();
+			HTMLFormElement.prototype.reset.call(a.form);
 			return true;
 		}
 		return false;

--- a/testdata/form.html
+++ b/testdata/form.html
@@ -14,8 +14,8 @@
     <input id="keyword" type="text" name="q" value="chromedp"/><br>
     <input id="foo" type="text" name="foo" value="foo"/><br>
     <textarea id="bar" rows="4" cols="50">bar</textarea><br>
-    <input id="btn1" type="reset" value="Reset">
-    <input id="btn2" type="submit" value="Submit">
+    <input id="btn1" name="reset" type="reset" value="Reset">
+    <input id="btn2" name="submit" type="submit" value="Submit">
     <p id="inner-hidden">this is <span style="display: none;">hidden</span></p>
     <p id="hidden" style="display: none;">hidden</p>
   </form>


### PR DESCRIPTION
fix #802

If a form control (such as a submit button) has a `name` or `id` of `submit`, it will mask the form's `submit` method. The same will happen to the `reset` method (see [HTMLFormElement.submit()](https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/submit)). The consequence is that it's not safe to call `form.submit()` or `form.reset()` directly. This PR fixes the issue by calling `submit`/`reset` like this: `HTMLFormElement.prototype.submit.call(form)`/`HTMLFormElement.prototype.reset.call(form)`.