### PR TITLE
make `NewRemoteAllocator` accept url without `devtools/browser/...`

### DIFF
--- a/allocate.go
+++ b/allocate.go
@@ -489,13 +489,9 @@ func CombinedOutput(w io.Writer) ExecAllocatorOption {
 // Because it contains "/devtools/browser/" and will be considered
 // as a valid websocket debugger URL.
 func NewRemoteAllocator(parent context.Context, url string) (context.Context, context.CancelFunc) {
-	url, err := detectURL(url)
-	if err != nil {
-		panic(fmt.Sprintf("failed to detect the websocket debugger url: %v", err))
-	}
 	ctx, cancel := context.WithCancel(parent)
 	c := &Context{Allocator: &RemoteAllocator{
-		wsURL: url,
+		wsURL: detectURL(url),
 	}}
 	ctx = context.WithValue(ctx, contextKey{}, c)
 	return ctx, cancel

--- a/allocate_test.go
+++ b/allocate_test.go
@@ -356,7 +356,7 @@ func TestModifyCmdFunc(t *testing.T) {
 	allocCtx, cancel := NewExecAllocator(context.Background(),
 		append([]ExecAllocatorOption{
 			ModifyCmdFunc(func(cmd *exec.Cmd) {
-				cmd.Env = append(cmd.Env, "TZ=" + tz)
+				cmd.Env = append(cmd.Env, "TZ="+tz)
 			}),
 		}, allocOpts...)...)
 	defer cancel()
@@ -375,4 +375,3 @@ func TestModifyCmdFunc(t *testing.T) {
 		t.Fatalf("got %s, want %s", ret, tz)
 	}
 }
-

--- a/allocate_test.go
+++ b/allocate_test.go
@@ -191,6 +191,7 @@ func testRemoteAllocator(t *testing.T, modifyURL func(wsURL string) string) {
 
 		// TODO: perhaps deduplicate this code with ExecAllocator
 		"--user-data-dir="+tempDir,
+		"--remote-debugging-address=0.0.0.0",
 		"--remote-debugging-port=0",
 		"about:blank",
 	)

--- a/allocate_test.go
+++ b/allocate_test.go
@@ -5,8 +5,10 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"os/exec"
 	"strings"
@@ -140,6 +142,26 @@ func TestRemoteAllocator(t *testing.T) {
 			name: "detect from http",
 			modifyURL: func(wsURL string) string {
 				return "http" + wsURL[2:strings.Index(wsURL, "devtools")]
+			},
+		},
+		{
+			name: "hostname",
+			modifyURL: func(wsURL string) string {
+				h, err := os.Hostname()
+				if err != nil {
+					t.Fatal(err)
+				}
+				u, err := url.Parse(wsURL)
+				if err != nil {
+					t.Fatal(err)
+				}
+				_, post, err := net.SplitHostPort(u.Host)
+				if err != nil {
+					t.Fatal(err)
+				}
+				u.Host = net.JoinHostPort(h, post)
+				u.Path = "/"
+				return u.String()
 			},
 		},
 	}

--- a/util.go
+++ b/util.go
@@ -1,8 +1,11 @@
 package chromedp
 
 import (
+	"encoding/json"
 	"net"
+	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/chromedp/cdproto"
 	"github.com/chromedp/cdproto/cdp"
@@ -27,6 +30,47 @@ func forceIP(urlstr string) string {
 	}
 	u.Host = net.JoinHostPort(addr.IP.String(), port)
 	return u.String()
+}
+
+// detectURL detects the websocket debugger URL if the provided URL is not a
+// valid websocket debugger URL.
+//
+// A valid websocket debugger URL is something like:
+// ws://127.0.0.1:9222/devtools/browser/...
+// The original URL with the following formats are accepted:
+// * ws://127.0.0.1:9222/
+// * http://127.0.0.1:9222/
+func detectURL(urlstr string) (string, error) {
+	if strings.Contains(urlstr, "/devtools/browser/") {
+		return urlstr, nil
+	}
+
+	// replace the scheme and path to construct the URL like:
+	// http://127.0.0.1:9222/json/version
+	u, err := url.Parse(urlstr)
+	if err != nil {
+		return "", err
+	}
+	u.Scheme = "http"
+	u.Path = "/json/version"
+
+	// to get "webSocketDebuggerUrl" in the response
+	resp, err := http.Get(u.String())
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	var result map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", err
+	}
+	// the browser will construct the debugger URL using the "host" header of the /json/version request.
+	// for example, run headless-shell in a container: docker run -d -p 9000:9222 chromedp/headless-shell:latest
+	// then: curl http://127.0.0.1:9000/json/version
+	// and the debugger URL will be something like: ws://127.0.0.1:9000/devtools/browser/...
+	wsURL := result["webSocketDebuggerUrl"].(string)
+	return wsURL, nil
 }
 
 func runListeners(list []cancelableListener, ev interface{}) []cancelableListener {

--- a/util.go
+++ b/util.go
@@ -55,7 +55,7 @@ func detectURL(urlstr string) string {
 	u.Path = "/json/version"
 
 	// to get "webSocketDebuggerUrl" in the response
-	resp, err := http.Get(u.String())
+	resp, err := http.Get(forceIP(u.String()))
 	if err != nil {
 		return urlstr
 	}


### PR DESCRIPTION
A full websocket debugger URL is something like this:

```
ws://127.0.0.1:9222/devtools/browser/120e6fb7-0094-47a2-8b4c-51741797f280
```

And the ID part is not static, which requires extra work to get the correct URL for `chromedp.NewRemoteAllocator`.

This change allows the client to just pass the base URL to `chromedp.NewRemoteAllocator`. It will send a request to `/json/version`  to get the full websocket debugger URL if the provided URL is not  a valid websocket debugger URL.

After the change, the URL with the following formats are accepted:
* `ws://127.0.0.1:9222/`
* `http://127.0.0.1:9222/`

Do not use URL in the following formats because they contain `/devtools/browser/` and will be considered as valid websocket debugger URLs:
* `ws://127.0.0.1:9222/devtools/browser/`
* `ws://127.0.0.1:9222/devtools/browser/`
* `http://127.0.0.1:9222/devtools/browser/120e6fb7-0094-47a2-8b4c-51741797f280`

Fixes #438.