### PR TITLE
set `chromedp.ByQuery` option explicitly in Example_retrieveHTML

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -362,9 +362,9 @@ function changeText() {
 	var outerBefore, outerAfter string
 	if err := chromedp.Run(ctx,
 		chromedp.Navigate(ts.URL),
-		chromedp.OuterHTML("#content", &outerBefore),
-		chromedp.Click("#content", chromedp.ByID),
-		chromedp.OuterHTML("#content", &outerAfter),
+		chromedp.OuterHTML("#content", &outerBefore, chromedp.ByQuery),
+		chromedp.Click("#content", chromedp.ByQuery),
+		chromedp.OuterHTML("#content", &outerAfter, chromedp.ByQuery),
 	); err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
It's not intuitive that the default query option is `chromedp.BySearch`. Most users will think that the `sel` is a css selector (`chromedp.ByQuery` or `chromedp.ByQueryAll`). Both `chromedp.BySearch` and `chromedp.ByQuery` work in the example, but very likely `chromedp.BySearch` does not work in user code if the `sel` is a css selector. Since `#content` is a css selector, it's better to set `chromedp.ByQuery` explicitly.

Regarding `chromedp.ByID` and `chromedp.ByQuery`, `chromedp.ByID` is a special case of `chromedp.ByQuery`, except that it tries to trim prefix `#` first and then add prefix `#`. I think the use of `chromedp.ByID` should not be encouraged.