### PR TITLE
doc: event handlers sending CDP messages should run in a separate goroutine

### DIFF
--- a/chromedp.go
+++ b/chromedp.go
@@ -652,7 +652,8 @@ type cancelableListener struct {
 //
 // Note that the function is called synchronously when handling events. The
 // function should avoid blocking at all costs. For example, any Actions must be
-// run via a separate goroutine.
+// run via a separate goroutine (otherwise, it could result in a deadlock if the
+// action sends CDP messages).
 func ListenBrowser(ctx context.Context, fn func(ev interface{})) {
 	c := FromContext(ctx)
 	if c == nil {
@@ -674,7 +675,8 @@ func ListenBrowser(ctx context.Context, fn func(ev interface{})) {
 //
 // Note that the function is called synchronously when handling events. The
 // function should avoid blocking at all costs. For example, any Actions must be
-// run via a separate goroutine.
+// run via a separate goroutine (otherwise, it could result in a deadlock if the
+// action sends CDP messages).
 func ListenTarget(ctx context.Context, fn func(ev interface{})) {
 	c := FromContext(ctx)
 	if c == nil {


### PR DESCRIPTION
Otherwise, it could result in a deadlock like this (see https://github.com/chromedp/chromedp/issues/805#issuecomment-842184606 for more information):

```
┌──────────┐          ┌─────────────┐          ┌──────────────┐
│Target.run│──waits──>│event handler│──calls──>│Target.Execute│
└────┬─────┘          └─────────────┘          └───────┬──────┘
     │                                                 │
     │                                                 │
     │             ┌──────────────────┐                │
     └────holds───>│Target.listenersMu│<────waits──────┘
                   └──────────────────┘
```