### PR TITLE
add /usr/local/bin/chrome for freebsd

### DIFF
--- a/allocate.go
+++ b/allocate.go
@@ -369,6 +369,7 @@ func findExecPath() string {
 			"google-chrome-beta",
 			"google-chrome-unstable",
 			"/usr/bin/google-chrome",
+			"/usr/local/bin/chrome",
 		}
 	}
 


### PR DESCRIPTION
fixes issue where chromedp doesn't find chrome when installed via `pkg install chromium` on freebsd/freenas/truenas