### PR TITLE
return ErrInvalidDimensions when the slice of content quads is empty

### DIFF
--- a/input.go
+++ b/input.go
@@ -69,6 +69,11 @@ func MouseClickNode(n *cdp.Node, opts ...MouseOption) MouseAction {
 		if err != nil {
 			return err
 		}
+
+		if len(boxes) == 0 {
+			return ErrInvalidDimensions
+		}
+
 		content := boxes[0]
 
 		c := len(content)


### PR DESCRIPTION
Fixes #697.