### PR TITLE
normalize error messages for property access on null/undefined

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -255,6 +255,11 @@ func ExampleListenTarget_consoleLog() {
 			// Since ts.URL uses a random port, replace it.
 			s := ev.ExceptionDetails.Error()
 			s = strings.ReplaceAll(s, ts.URL, "<server>")
+			// V8 has changed the error messages for property access on null/undefined in version 9.3.310.
+			// see: https://chromium.googlesource.com/v8/v8/+/c0fd89c3c089e888c4f4e8582e56db7066fa779b
+			//      https://github.com/chromium/chromium/commit/1735cbf94c98c70ff7554a1e9e01bb9a4f91beb6
+			// The message is normalized to make it compatible with the versions before this change.
+			s = strings.ReplaceAll(s, "Cannot read property 'throwsException' of null", "Cannot read properties of null (reading 'throwsException')")
 			fmt.Printf("* %s\n", s)
 			gotException <- true
 		}
@@ -271,7 +276,7 @@ func ExampleListenTarget_consoleLog() {
 	// * console.warning call:
 	// string - "scary warning"
 	// number - 123
-	// * exception "Uncaught" (4:6): TypeError: Cannot read property 'throwsException' of null
+	// * exception "Uncaught" (4:6): TypeError: Cannot read properties of null (reading 'throwsException')
 	//     at <server>/:5:7
 }
 


### PR DESCRIPTION
V8 has changed the error messages for property access on null/undefined in version 9.3.310.
see:
- https://chromium.googlesource.com/v8/v8/+/c0fd89c3c089e888c4f4e8582e56db7066fa779b
- https://github.com/chromium/chromium/commit/1735cbf94c98c70ff7554a1e9e01bb9a4f91beb6

So we should normalize the error message to make it compatible with the versions before this change.
