### PR TITLE
Update go directive to 1.17 and cdproto to 98.0.4702.1_9.8.37

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/chromedp/chromedp
 go 1.17
 
 require (
-	github.com/chromedp/cdproto v0.0.0-20210808225517-c36c1bd4c35e
+	github.com/chromedp/cdproto v0.0.0-20211112223831-e508c7bf6446
 	github.com/gobwas/ws v1.1.0
 	github.com/mailru/easyjson v0.7.7
 	github.com/orisano/pixelmatch v0.0.0-20210112091706-4fa4c7ba91d5

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,18 @@
 module github.com/chromedp/chromedp
 
-go 1.16
+go 1.17
 
 require (
 	github.com/chromedp/cdproto v0.0.0-20210808225517-c36c1bd4c35e
 	github.com/gobwas/ws v1.1.0
 	github.com/mailru/easyjson v0.7.7
 	github.com/orisano/pixelmatch v0.0.0-20210112091706-4fa4c7ba91d5
+)
+
+require (
+	github.com/chromedp/sysutil v1.0.0 // indirect
+	github.com/gobwas/httphead v0.1.0 // indirect
+	github.com/gobwas/pool v0.2.1 // indirect
+	github.com/josharian/intern v1.0.0 // indirect
 	golang.org/x/sys v0.0.0-20210806184541-e5e7981a1069 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/chromedp/cdproto v0.0.0-20210808225517-c36c1bd4c35e h1:uYQIvPKwL7YQh+tQC+EUXmvWosBeOYbJZKrh4NnS0UM=
-github.com/chromedp/cdproto v0.0.0-20210808225517-c36c1bd4c35e/go.mod h1:At5TxYYdxkbQL0TSefRjhLE3Q0lgvqKKMSFUglJ7i1U=
+github.com/chromedp/cdproto v0.0.0-20211112223831-e508c7bf6446 h1:uG7ssld4pEDC5O+1UoKqMb0djjJb8qjuKZVnCskGY+s=
+github.com/chromedp/cdproto v0.0.0-20211112223831-e508c7bf6446/go.mod h1:At5TxYYdxkbQL0TSefRjhLE3Q0lgvqKKMSFUglJ7i1U=
 github.com/chromedp/sysutil v1.0.0 h1:+ZxhTpfpZlmchB58ih/LBHX52ky7w2VhQVKQMucy3Ic=
 github.com/chromedp/sysutil v1.0.0/go.mod h1:kgWmDdq8fTzXYcKIBqIYvRRTnYb9aNS9moAV0xufSww=
 github.com/gobwas/httphead v0.1.0 h1:exrUm0f4YX0L7EBwZHuCF4GDp8aJfVeBrlLQrs6NqWU=


### PR DESCRIPTION
Update go.mod `go` directive to `1.17`, and update `cdproto` to [`98.0.4702.1_9.8.37`](https://github.com/chromedp/cdproto/commit/e508c7bf6446ba291dfaf92ffc84822d5cf88e8a).