### PR TITLE
reduce the parallel execution of test functions to reduce CPU load in resource-constraint environment (Github hosted runners)

### DIFF
--- a/contrib/docker-test.sh
+++ b/contrib/docker-test.sh
@@ -18,7 +18,7 @@ set -e
     --workdir=/chromedp \
     --env=PATH=/headless-shell \
     --env=HEADLESS_SHELL=1 \
-    chromedp/headless-shell:latest -test.v
+    chromedp/headless-shell:latest -test.v -test.parallel=1 -test.timeout=3m
 )
 
 popd &> /dev/null


### PR DESCRIPTION
It also sets the test timeout so that the test won't hang when there is something wrong.

Fixes #974