### PR TITLE
add both forms of build flag to files

### DIFF
--- a/allocate_linux.go
+++ b/allocate_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package chromedp

--- a/allocate_other.go
+++ b/allocate_other.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package chromedp

--- a/device/gen.go
+++ b/device/gen.go
@@ -1,4 +1,5 @@
 //go:build ignore
+// +build ignore
 
 package main
 

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/chromedp/cdproto v0.0.0-20220321060548-7bc2623472b3 h1:ilF7R875ORf246k6nU2/6fRIbtAFYjPOOtwZJTQvusM=
-github.com/chromedp/cdproto v0.0.0-20220321060548-7bc2623472b3/go.mod h1:5Y4sD/eXpwrChIuxhSr/G20n9CdbCmoerOHnuAf0Zr0=
 github.com/chromedp/cdproto v0.0.0-20220428002153-285dfb42699c h1:9VfguIWKAk161/xCyWLV23cJQmL3pDXKJHUSySQxT3s=
 github.com/chromedp/cdproto v0.0.0-20220428002153-285dfb42699c/go.mod h1:5Y4sD/eXpwrChIuxhSr/G20n9CdbCmoerOHnuAf0Zr0=
 github.com/chromedp/sysutil v1.0.0 h1:+ZxhTpfpZlmchB58ih/LBHX52ky7w2VhQVKQMucy3Ic=
@@ -16,7 +14,6 @@ github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/orisano/pixelmatch v0.0.0-20210112091706-4fa4c7ba91d5 h1:1SoBaSPudixRecmlHXb/GxmaD3fLMtHIDN13QujwQuc=
 github.com/orisano/pixelmatch v0.0.0-20210112091706-4fa4c7ba91d5/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=
-golang.org/x/sys v0.0.0-20201207223542-d4d67f95c62d h1:MiWWjyhUzZ+jvhZvloX6ZrUsdEghn8a64Upd8EMHglE=
 golang.org/x/sys v0.0.0-20201207223542-d4d67f95c62d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20220422013727-9388b58f7150 h1:xHms4gcpe1YE7A3yIllJXP16CMAGuqwO2lX1mTyyRRc=
 golang.org/x/sys v0.0.0-20220422013727-9388b58f7150/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/kb/gen.go
+++ b/kb/gen.go
@@ -1,4 +1,5 @@
 //go:build ignore
+// +build ignore
 
 package main
 
@@ -626,7 +627,7 @@ func Encode(r rune) []*input.DispatchKeyEventParams {
 // DOM keys.
 const (
 	%s)
-	
+
 // Keys is the map of unicode characters to their DOM key data.
 var Keys = map[rune]*Key{
 	%s}


### PR DESCRIPTION
If we just use `//go:build`, it will drop support for Go <= 1.17.

see https://go.googlesource.com/proposal/+/master/design/draft-gobuild.md