### PR TITLE
skip TestGracefulBrowserShutdown in the headless-shell image

### DIFF
--- a/chromedp_test.go
+++ b/chromedp_test.go
@@ -672,6 +672,10 @@ func TestDownloadIntoDir(t *testing.T) {
 func TestGracefulBrowserShutdown(t *testing.T) {
 	t.Parallel()
 
+	if os.Getenv("HEADLESS_SHELL") != "" {
+		t.Skip(`Skip in headless-shell due to https://github.com/chromedp/chromedp/issues/1078`)
+	}
+
 	dir, err := ioutil.TempDir("", "chromedp-test")
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
The cookies is not saved to disk since `chromedp/headless-shell:99.0.4818.2` which causes the test to fail.

This commit should be reverted after the issue has been fixed.

For #1078