### PR TITLE
Revert "skip TestGracefulBrowserShutdown in the headless-shell image"

### DIFF
--- a/chromedp_test.go
+++ b/chromedp_test.go
@@ -672,10 +672,6 @@ func TestDownloadIntoDir(t *testing.T) {
 func TestGracefulBrowserShutdown(t *testing.T) {
 	t.Parallel()
 
-	if os.Getenv("HEADLESS_SHELL") != "" {
-		t.Skip(`Skip in headless-shell due to https://github.com/chromedp/chromedp/issues/1078`)
-	}
-
 	dir, err := ioutil.TempDir("", "chromedp-test")
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
This reverts commit 9fcaa22de31f9642e6e9994ae132b67e3d41bb90.

The issue #1078 should have been fixed by https://github.com/chromedp/docker-headless-shell/pull/17.