### PR TITLE
Guard access to Target.{frames,cur} globally

### DIFF
--- a/chromedp.go
+++ b/chromedp.go
@@ -623,9 +623,9 @@ func responseAction(resp **network.Response, actions ...Action) Action {
 
 		// Obtain frameID from the target.
 		c := FromContext(ctx)
-		c.Target.frameMu.Lock()
+		c.Target.frameMu.RLock()
 		frameID = c.Target.cur
-		c.Target.frameMu.Unlock()
+		c.Target.frameMu.RUnlock()
 
 		ListenTarget(lctx, func(ev interface{}) {
 			if loaderID != "" {

--- a/chromedp.go
+++ b/chromedp.go
@@ -351,8 +351,12 @@ func (c *Context) newTarget(ctx context.Context) error {
 			if err != nil {
 				return err
 			}
+
+			c.Target.frameMu.Lock()
 			c.Target.frames[tree.Frame.ID] = tree.Frame
 			c.Target.cur = tree.Frame.ID
+			c.Target.frameMu.Unlock()
+
 			c.Target.documentUpdated(ctx)
 		}
 		return nil

--- a/target.go
+++ b/target.go
@@ -360,7 +360,10 @@ func (t *Target) pageEvent(ev interface{}) {
 
 // domEvent handles incoming DOM events.
 func (t *Target) domEvent(ctx context.Context, ev interface{}) {
+	t.frameMu.RLock()
 	f := t.frames[t.cur]
+	t.frameMu.RUnlock()
+
 	var id cdp.NodeID
 	var op nodeOp
 

--- a/target.go
+++ b/target.go
@@ -28,7 +28,7 @@ type Target struct {
 
 	messageQueue chan *cdproto.Message
 
-	// frameMu protects both frames and cur.
+	// frameMu protects frames, execContexts, and cur.
 	frameMu sync.RWMutex
 	// frames is the set of encountered frames.
 	frames       map[cdp.FrameID]*cdp.Frame


### PR DESCRIPTION
Some accesses to `Target.frames` and `Target.cur` are not guarded by `Target.frameMu` unintentionally. Which leads to data race.

Fixes: #1110
Fixes: #1296
