### PR TITLE
Bugfix: Include missing return value for matching struct

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/chromedp/chromedp
 go 1.18
 
 require (
-	github.com/chromedp/cdproto v0.0.0-20220515234810-83d799542a04
+	github.com/chromedp/cdproto v0.0.0-20220720105051-fd2b6dcad39e
 	github.com/gobwas/ws v1.1.0
 	github.com/mailru/easyjson v0.7.7
 	github.com/orisano/pixelmatch v0.0.0-20210112091706-4fa4c7ba91d5
@@ -14,5 +14,5 @@ require (
 	github.com/gobwas/httphead v0.1.0 // indirect
 	github.com/gobwas/pool v0.2.1 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
-	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a // indirect
+	golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/chromedp/cdproto v0.0.0-20220515234810-83d799542a04 h1:8GLetRp0N/g2MVzUmFRBXgLJTPofYAdTyWNR2lC0EQM=
-github.com/chromedp/cdproto v0.0.0-20220515234810-83d799542a04/go.mod h1:5Y4sD/eXpwrChIuxhSr/G20n9CdbCmoerOHnuAf0Zr0=
+github.com/chromedp/cdproto v0.0.0-20220720105051-fd2b6dcad39e h1:AX1yO5n3vfVFvwPtuJAp6ut5qq+MU2Rir5yO9+yk1Mg=
+github.com/chromedp/cdproto v0.0.0-20220720105051-fd2b6dcad39e/go.mod h1:5Y4sD/eXpwrChIuxhSr/G20n9CdbCmoerOHnuAf0Zr0=
 github.com/chromedp/sysutil v1.0.0 h1:+ZxhTpfpZlmchB58ih/LBHX52ky7w2VhQVKQMucy3Ic=
 github.com/chromedp/sysutil v1.0.0/go.mod h1:kgWmDdq8fTzXYcKIBqIYvRRTnYb9aNS9moAV0xufSww=
 github.com/gobwas/httphead v0.1.0 h1:exrUm0f4YX0L7EBwZHuCF4GDp8aJfVeBrlLQrs6NqWU=
@@ -15,5 +15,5 @@ github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJ
 github.com/orisano/pixelmatch v0.0.0-20210112091706-4fa4c7ba91d5 h1:1SoBaSPudixRecmlHXb/GxmaD3fLMtHIDN13QujwQuc=
 github.com/orisano/pixelmatch v0.0.0-20210112091706-4fa4c7ba91d5/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=
 golang.org/x/sys v0.0.0-20201207223542-d4d67f95c62d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a h1:dGzPydgVsqGcTRVwiLJ1jVbufYwmzD3LfVPLKsKg+0k=
-golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 h1:0A+M6Uqn+Eje4kHMK80dtF3JCXC4ykBgQG4Fe06QRhQ=
+golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/query.go
+++ b/query.go
@@ -1136,7 +1136,7 @@ func MatchedStyle(sel interface{}, style **css.GetMatchedStylesForNodeReturns, o
 		ret := &css.GetMatchedStylesForNodeReturns{}
 		ret.InlineStyle, ret.AttributesStyle, ret.MatchedCSSRules,
 			ret.PseudoElements, ret.Inherited, ret.InheritedPseudoElements,
-			ret.CSSKeyframesRules, err = css.GetMatchedStylesForNode(nodes[0].NodeID).Do(ctx)
+			ret.CSSKeyframesRules, ret.ParentLayoutNodeID, err = css.GetMatchedStylesForNode(nodes[0].NodeID).Do(ctx)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This addresses #1121

The corresponding data structure in [cdproto](https://github.com/chromedp/cdproto/blob/fd2b6dcad39e613805488dc3741d812877eab918/css/css.go#L357) was updated and broke the dependent function call in `chromedp/query.go`.