### PR TITLE
Fix example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ for an example.
 Wrap it with an `ActionFunc`:
 
 ```go
-ctx, cancel := chromedp.NewContext()
+ctx, cancel := chromedp.NewContext(context.Background())
 defer cancel()
 chromedp.Run(ctx, chromedp.ActionFunc(func(ctx context.Context) error {
 	_, err := domain.SomeAction().Do(ctx)


### PR DESCRIPTION
I've added the required argument in this example, as it wouldn't work as it is now.