### PR TITLE
remote allocator support option

### DIFF
--- a/allocate.go
+++ b/allocate.go
@@ -536,7 +536,7 @@ func setupRemoteAllocator(opts ...RemoteAllocatorOption) *RemoteAllocator {
 // as a valid websocket debugger URL.
 func NewRemoteAllocator(parent context.Context, url string, opts ...RemoteAllocatorOption) (context.Context, context.CancelFunc) {
 	ctx, cancel := context.WithCancel(parent)
-	opts = append(opts, remoteUrl(url))
+	opts = append(opts, remoteUrl(detectURL(url)))
 	c := &Context{Allocator: setupRemoteAllocator(opts...)}
 	ctx = context.WithValue(ctx, contextKey{}, c)
 	return ctx, cancel


### PR DESCRIPTION
## Changes
- Added `RemoteAllocatorOption` parameter to `NewRemoteAllocator`.
- `Param` is a generic option to pass a flag to remote url. If the value is a string and isFlag is true, it will be passed as --name=value. If it's a boolean, it will be passed as --name if value is true. If isFlag is false, it will be passed as name=value. If it's a boolean, it will be passed as name if value is true.

## Demo
```go
	devtoolsWsURL := "wss://chrome.browserless.io"
	opts := []chromedp.RemoteAllocatorOption{
		chromedp.Param("token", "YOUR_API_KEY", false),
		chromedp.Param("user-agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.127 Safari/537.36", true),
	}
	allocatorContext, cancel := chromedp.NewRemoteAllocator(context.Background(), devtoolsWsURL, opts...)
```