### PR TITLE
introduce a remote allocator option: NoModifyURL

### DIFF
--- a/allocate.go
+++ b/allocate.go
@@ -556,7 +556,8 @@ func (a *RemoteAllocator) Allocate(ctx context.Context, opts ...BrowserOption) (
 		cancel()    // close the websocket connection
 		a.wg.Done()
 	}()
-	browser, err := NewBrowser(wctx, a.wsURL, opts...)
+	wsURL := forceIP(a.wsURL)
+	browser, err := NewBrowser(wctx, wsURL, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/allocate.go
+++ b/allocate.go
@@ -523,7 +523,7 @@ func WSURLReadTimeout(t time.Duration) ExecAllocatorOption {
 func NewRemoteAllocator(parent context.Context, url string) (context.Context, context.CancelFunc) {
 	ctx, cancel := context.WithCancel(parent)
 	c := &Context{Allocator: &RemoteAllocator{
-		wsURL: detectURL(url),
+		wsURL: url,
 	}}
 	ctx = context.WithValue(ctx, contextKey{}, c)
 	return ctx, cancel
@@ -556,7 +556,8 @@ func (a *RemoteAllocator) Allocate(ctx context.Context, opts ...BrowserOption) (
 		cancel()    // close the websocket connection
 		a.wg.Done()
 	}()
-	wsURL := forceIP(a.wsURL)
+	wsURL := detectURL(a.wsURL)
+	wsURL = forceIP(wsURL)
 	browser, err := NewBrowser(wctx, wsURL, opts...)
 	if err != nil {
 		return nil, err

--- a/browser.go
+++ b/browser.go
@@ -109,7 +109,6 @@ func NewBrowser(ctx context.Context, urlstr string, opts ...BrowserOption) (*Bro
 	}
 
 	var err error
-	urlstr = forceIP(urlstr)
 	b.conn, err = DialContext(dialCtx, urlstr, WithConnDebugf(b.dbgf))
 	if err != nil {
 		return nil, fmt.Errorf("could not dial %q: %w", urlstr, err)


### PR DESCRIPTION
The feature implemented by #817 makes chromedp not work with [browserless](https://www.browserless.io/). In order to address this issue, a new remote allocator option is introduced: `chromedp.NoModifyURL`. Usage:

```go
ctx, cancel := chromedp.NewRemoteAllocator(context.Background(), "wss://chrome.browserless.io?token=YOUR-API-TOKEN", chromedp.NoModifyURL)
```

Fixes #972.