### PR TITLE
Remove ioutil because it is deprecated since go1.16

### DIFF
--- a/device/gen.go
+++ b/device/gen.go
@@ -10,7 +10,7 @@ import (
 	"flag"
 	"fmt"
 	"go/format"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"regexp"
@@ -81,7 +81,7 @@ func run(out string) error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(out, src, 0o644)
+	return os.WriteFile(out, src, 0o644)
 }
 
 var (
@@ -108,7 +108,7 @@ func get(v interface{}) error {
 	if res.StatusCode != 200 {
 		return fmt.Errorf("got status code %d", res.StatusCode)
 	}
-	buf, err := ioutil.ReadAll(res.Body)
+	buf, err := io.ReadAll(res.Body)
 	if err != nil {
 		return err
 	}

--- a/kb/gen.go
+++ b/kb/gen.go
@@ -10,7 +10,7 @@ import (
 	"flag"
 	"fmt"
 	"go/format"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"regexp"
@@ -48,7 +48,7 @@ func run(out string) error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(out, src, 0o644)
+	return os.WriteFile(out, src, 0o644)
 }
 
 // loadKeys loads the dom key definitions from the chromium source tree.
@@ -439,7 +439,7 @@ func grab(path string) ([]byte, error) {
 		return nil, fmt.Errorf("unable to get %s: %w", path, err)
 	}
 	defer res.Body.Close()
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return nil, fmt.Errorf("unable to read %s: %w", path, err)
 	}


### PR DESCRIPTION
 This PR replaces `ioutil`package usages with `io` or `os` because `ioutil` is [deprecated](https://pkg.go.dev/io/ioutil).

From the doc:
```
As of Go 1.16, the same functionality is now provided by package io or package os
```