### PR TITLE
kb: fix chromium src URL

### DIFF
--- a/kb/gen.go
+++ b/kb/gen.go
@@ -464,7 +464,7 @@ var goCodes = map[rune]string{
 
 const (
 	// chromiumSrc is the base chromium source repo location
-	chromiumSrc = "https://chromium.googlesource.com/chromium/src/+/master/"
+	chromiumSrc = "https://chromium.googlesource.com/chromium/src/+/main/"
 	// domUsLayoutDataH contains the {printable,non-printable} DomCode -> DomKey
 	// also contains DomKey -> VKEY (not used)
 	domUsLayoutDataH = chromiumSrc + "ui/events/keycodes/dom_us_layout_data.h?format=TEXT"


### PR DESCRIPTION
This PR fixes the value of `chromiumSrc` in `gen.go` to fix the following error when running `kb/gen.go`:
```
error: unable to base64 decode https://chromium.googlesource.com/chromium/src/+/master/ui/events/keycodes/dom/dom_code_data.inc?format=TEXT: illegal base64 data at input byte 3
>>>
NOT_FOUND: Requested entity was not found
[type.googleapis.com/google.rpc.LocalizedMessage]
locale: "en-US"
message: "Cannot parse URL as a Gitiles URL"

[type.googleapis.com/google.rpc.RequestInfo]
request_id: "ac54bf5d4830467b99ef107dcaac8a0b"


<<<
```