### PR TITLE
docs: Apply godoc format to lists and links

### DIFF
--- a/allocate.go
+++ b/allocate.go
@@ -50,7 +50,7 @@ func setupExecAllocator(opts ...ExecAllocatorOption) *ExecAllocator {
 
 // DefaultExecAllocatorOptions are the ExecAllocator options used by NewContext
 // if the given parent context doesn't have an allocator set up. Do not modify
-// this global; instead, use NewExecAllocator. See ExampleExecAllocator.
+// this global; instead, use NewExecAllocator. See the example for [ExecAllocator].
 var DefaultExecAllocatorOptions = [...]ExecAllocatorOption{
 	NoFirstRun,
 	NoDefaultBrowserCheck,
@@ -482,11 +482,12 @@ func Headless(a *ExecAllocator) {
 //
 // The --disable-gpu option is a temporary workaround for a few bugs
 // in headless mode. According to the references below, it's no longer required:
-// - https://bugs.chromium.org/p/chromium/issues/detail?id=737678
-// - https://github.com/puppeteer/puppeteer/pull/2908
-// - https://github.com/puppeteer/puppeteer/pull/4523
+//   - https://bugs.chromium.org/p/chromium/issues/detail?id=737678
+//   - https://github.com/puppeteer/puppeteer/pull/2908
+//   - https://github.com/puppeteer/puppeteer/pull/4523
+//
 // But according to this reported issue, it's still required in some cases:
-// - https://github.com/chromedp/chromedp/issues/904
+//   - https://github.com/chromedp/chromedp/issues/904
 func DisableGPU(a *ExecAllocator) {
 	Flag("disable-gpu", true)(a)
 }
@@ -515,8 +516,8 @@ func WSURLReadTimeout(t time.Duration) ExecAllocatorOption {
 // the correct one by sending a request to "http://$HOST:$PORT/json/version".
 //
 // The url with the following formats are accepted:
-// * ws://127.0.0.1:9222/
-// * http://127.0.0.1:9222/
+//   - ws://127.0.0.1:9222/
+//   - http://127.0.0.1:9222/
 //
 // But "ws://127.0.0.1:9222/devtools/browser/" are not accepted.
 // Because the allocator won't try to modify it and it's obviously invalid.

--- a/allocate.go
+++ b/allocate.go
@@ -50,7 +50,9 @@ func setupExecAllocator(opts ...ExecAllocatorOption) *ExecAllocator {
 
 // DefaultExecAllocatorOptions are the ExecAllocator options used by NewContext
 // if the given parent context doesn't have an allocator set up. Do not modify
-// this global; instead, use NewExecAllocator. See the example for [ExecAllocator].
+// this global; instead, use NewExecAllocator. See [ExampleExecAllocator].
+//
+// [ExampleExecAllocator]: https://pkg.go.dev/github.com/chromedp/chromedp#example-ExecAllocator
 var DefaultExecAllocatorOptions = [...]ExecAllocatorOption{
 	NoFirstRun,
 	NoDefaultBrowserCheck,

--- a/browser.go
+++ b/browser.go
@@ -122,13 +122,15 @@ func NewBrowser(ctx context.Context, urlstr string, opts ...BrowserOption) (*Bro
 //
 // It could be nil when the browser is allocated with RemoteAllocator.
 // It could be useful for a monitoring system to collect process metrics of the browser process.
-// (see https://pkg.go.dev/github.com/prometheus/client_golang/prometheus#NewProcessCollector for an example)
+// (See [prometheus.NewProcessCollector] for an example).
 //
 // Example:
 //
 //	if process := chromedp.FromContext(ctx).Browser.Process(); process != nil {
 //		fmt.Printf("Browser PID: %v", process.Pid)
 //	}
+//
+// [prometheus.NewProcessCollector]: https://pkg.go.dev/github.com/prometheus/client_golang/prometheus#NewProcessCollector
 func (b *Browser) Process() *os.Process {
 	return b.process
 }

--- a/chromedp.go
+++ b/chromedp.go
@@ -6,7 +6,9 @@
 // DevTools Protocol entirely in Go.
 //
 // This package includes a number of simple examples. Additionally,
-// https://github.com/chromedp/examples contains more complex examples.
+// [chromedp/examples] contains more complex examples.
+//
+// [chromedp/examples]: https://github.com/chromedp/examples
 package chromedp
 
 import (
@@ -91,7 +93,7 @@ type Context struct {
 //
 // Cancelling the returned context will close a tab or an entire browser,
 // depending on the logic described above. To cancel a context while checking
-// for errors, see Cancel.
+// for errors, see [Cancel].
 //
 // Note that NewContext doesn't allocate nor start a browser; that happens the
 // first time Run is used on the context.

--- a/emulate.go
+++ b/emulate.go
@@ -82,8 +82,7 @@ func ResetViewport() EmulateAction {
 
 // Device is the shared interface for known device types.
 //
-// See: github.com/chromedp/chromedp/device for a set of off-the-shelf devices
-// and modes.
+// See [device] for a set of off-the-shelf devices and modes.
 type Device interface {
 	// Device returns the device info.
 	Device() device.Info
@@ -91,8 +90,7 @@ type Device interface {
 
 // Emulate is an action to emulate a specific device.
 //
-// See: github.com/chromedp/chromedp/device for a set of off-the-shelf devices
-// and modes.
+// See [device] for a set of off-the-shelf devices and modes.
 func Emulate(device Device) EmulateAction {
 	d := device.Device()
 

--- a/eval.go
+++ b/eval.go
@@ -99,7 +99,7 @@ func parseRemoteObject(v *runtime.RemoteObject, res interface{}) (undefined bool
 // Chrome DevTools would, evaluating the expression in the "console" context,
 // and making the Command Line API available to the script.
 //
-// See Evaluate for more information on how script expressions are evaluated.
+// See [Evaluate] for more information on how script expressions are evaluated.
 //
 // Note: this should not be used with untrusted JavaScript.
 func EvaluateAsDevTools(expression string, res interface{}, opts ...EvaluateOption) EvaluateAction {
@@ -119,7 +119,7 @@ func EvalObjectGroup(objectGroup string) EvaluateOption {
 // EvalWithCommandLineAPI is an evaluate option to make the DevTools Command
 // Line API available to the evaluated script.
 //
-// See Evaluate for more information on how evaluate actions work.
+// See [Evaluate] for more information on how evaluate actions work.
 //
 // Note: this should not be used with untrusted JavaScript.
 func EvalWithCommandLineAPI(p *runtime.EvaluateParams) *runtime.EvaluateParams {

--- a/input.go
+++ b/input.go
@@ -158,10 +158,10 @@ type KeyAction Action
 //
 // Only well-known, "printable" characters will have char events synthesized.
 //
-// See the SendKeys action to synthesize key events for a specific element
+// See the [SendKeys] action to synthesize key events for a specific element
 // node.
 //
-// See the chromedp/kb package for implementation details and list of
+// See the [kb] package for implementation details and list of
 // well-known keys.
 func KeyEvent(keys string, opts ...KeyOption) KeyAction {
 	return ActionFunc(func(ctx context.Context) error {

--- a/nav.go
+++ b/nav.go
@@ -12,7 +12,7 @@ import (
 // for the page to load.
 //
 // Note that these actions don't collect HTTP response information; for that,
-// see RunResponse.
+// see [RunResponse].
 type NavigateAction Action
 
 // Navigate is an action that navigates the current frame.

--- a/poll.go
+++ b/poll.go
@@ -11,7 +11,7 @@ import (
 
 // PollAction are actions that will wait for a general JavaScript predicate.
 //
-// See Poll for details on building poll tasks.
+// See [Poll] for details on building poll tasks.
 type PollAction Action
 
 // pollTask holds information pertaining to an poll task.
@@ -85,8 +85,7 @@ func (p *pollTask) Do(ctx context.Context) error {
 // Poll is a poll action that will wait for a general JavaScript predicate.
 // It builds the predicate from a JavaScript expression.
 //
-// This is a copy of puppeteer's page.waitForFunction.
-// see https://github.com/puppeteer/puppeteer/blob/v8.0.0/docs/api.md#pagewaitforfunctionpagefunction-options-args.
+// This is a copy of puppeteer's [page.waitForFunction].
 // It's named Poll intentionally to avoid messing up with the Wait* query actions.
 // The behavior is not guaranteed to be compatible.
 // For example, our implementation makes the poll task not survive from a navigation,
@@ -107,7 +106,9 @@ func (p *pollTask) Do(ctx context.Context) error {
 //
 // The WithPollingArgs option provides extra arguments to pass to the predicate.
 // Only apply this option when the predicate is built from a function.
-// See PollFunction.
+// See [PollFunction].
+//
+// [page.waitForFunction]: https://github.com/puppeteer/puppeteer/blob/v8.0.0/docs/api.md#pagewaitforfunctionpagefunction-options-args
 func Poll(expression string, res interface{}, opts ...PollOption) PollAction {
 	predicate := fmt.Sprintf(`return (%s);`, expression)
 	return poll(predicate, res, opts...)
@@ -116,7 +117,7 @@ func Poll(expression string, res interface{}, opts ...PollOption) PollAction {
 // PollFunction is a poll action that will wait for a general JavaScript predicate.
 // It builds the predicate from a JavaScript function.
 //
-// See Poll for details on building poll tasks.
+// See [Poll] for details on building poll tasks.
 func PollFunction(pageFunction string, res interface{}, opts ...PollOption) PollAction {
 	predicate := fmt.Sprintf(`return (%s)(...args);`, pageFunction)
 

--- a/query.go
+++ b/query.go
@@ -18,12 +18,12 @@ import (
 // QueryAction are element query actions that select node elements from the
 // browser's DOM for retrieval or manipulation.
 //
-// See Query for details on building element query selectors.
+// See [Query] for details on building element query selectors.
 type QueryAction Action
 
 // Selector holds information pertaining to an element selection query.
 //
-// See Query for information on building an element selector and relevant
+// See [Query] for information on building an element selector and relevant
 // options.
 type Selector struct {
 	sel           interface{}
@@ -39,7 +39,7 @@ type Selector struct {
 // node(s) matching the criteria.
 //
 // Query actions that target a browser DOM element node (or nodes) make use of
-// Query, in conjunction with the After option (see below) to retrieve data or
+// Query, in conjunction with the After option to retrieve data or
 // to modify the element(s) selected by the query.
 //
 // For example:
@@ -57,11 +57,11 @@ type Selector struct {
 //
 // Where:
 //
-// - Action         : the action to perform
-// - selector       : element query selection (typically a string), that any matching node(s) will have the action applied
-// - parameter[1-N] : parameter(s) needed for the individual action (if any)
-// - result         : pointer to a result (if any)
-// - queryOptions   : changes how queries are executed, or how nodes are waited for (see below)
+//   - Action the action to perform
+//   - selector element query selection (typically a string), that any matching node(s) will have the action applied
+//   - parameter[1-N] parameter(s) needed for the individual action (if any)
+//   - result pointer to a result (if any)
+//   - queryOptions changes how queries are executed, or how nodes are waited for
 //
 // # Query Options
 //
@@ -1021,11 +1021,12 @@ func DoubleClick(sel interface{}, opts ...QueryOption) QueryAction {
 // events as needed for the runes in v, sending them to the first element node
 // matching the selector.
 //
-// For a complete example on how to use SendKeys, see
-// https://github.com/chromedp/examples/tree/master/keys.
+// See the [keys] for a complete example on how to use SendKeys.
 //
 // Note: when the element query matches a input[type="file"] node, then
 // dom.SetFileInputFiles is used to set the upload path of the input node to v.
+//
+// [keys]: https://github.com/chromedp/examples/tree/master/keys
 func SendKeys(sel interface{}, v string, opts ...QueryOption) QueryAction {
 	return QueryAfter(sel, func(ctx context.Context, execCtx runtime.ExecutionContextID, nodes ...*cdp.Node) error {
 		if len(nodes) < 1 {

--- a/query.go
+++ b/query.go
@@ -39,65 +39,65 @@ type Selector struct {
 // node(s) matching the criteria.
 //
 // Query actions that target a browser DOM element node (or nodes) make use of
-// Query, in conjunction with the After option to retrieve data or
+// Query, in conjunction with the [After] option to retrieve data or
 // to modify the element(s) selected by the query.
 //
 // For example:
 //
 //	chromedp.Run(ctx, chromedp.SendKeys(`thing`, chromedp.ByID))
 //
-// The above will perform a "SendKeys" action on the first element matching a
+// The above will perform a [SendKeys] action on the first element matching a
 // browser CSS query for "#thing".
 //
-// Element selection queries work in conjunction with specific actions and form
-// the primary way of automating Tasks in the browser. They are typically
+// [Element] selection queries work in conjunction with specific actions and form
+// the primary way of automating [Tasks] in the browser. They are typically
 // written in the following form:
 //
 //	Action(selector[, parameter1, ...parameterN][,result][, queryOptions...])
 //
 // Where:
 //
-//   - Action the action to perform
-//   - selector element query selection (typically a string), that any matching node(s) will have the action applied
-//   - parameter[1-N] parameter(s) needed for the individual action (if any)
-//   - result pointer to a result (if any)
-//   - queryOptions changes how queries are executed, or how nodes are waited for
+//   - Action - the action to perform
+//   - selector - element query selection (typically a string), that any matching node(s) will have the action applied
+//   - parameter[1-N] - parameter(s) needed for the individual action (if any)
+//   - result - pointer to a result (if any)
+//   - queryOptions - changes how queries are executed, or how nodes are waited for
 //
 // # Query Options
 //
 // By* options specify the type of element query used By the browser to perform
-// the selection query. When not specified, element queries will use BySearch
+// the selection query. When not specified, element queries will use [BySearch]
 // (a wrapper for DOM.performSearch).
 //
 // Node* options specify node conditions that cause the query to wait until the
 // specified condition is true. When not specified, queries will use the
-// NodeReady wait condition.
+// [NodeReady] wait condition.
 //
-// The AtLeast option alters the minimum number of nodes that must be returned
+// The [AtLeast] option alters the minimum number of nodes that must be returned
 // by the element query. If not specified, the default value is 1.
 //
-// The After option is used to specify a func that will be executed when
+// The [After] option is used to specify a func that will be executed when
 // element query has returned one or more elements, and after the node condition is
 // true.
 //
 // # By Options
 //
-// The BySearch (default) option enables querying for elements by plain text,
+// The [BySearch] (default) option enables querying for elements by plain text,
 // CSS selector or XPath query, wrapping DOM.performSearch.
 //
-// The ByID option enables querying for a single element with the matching CSS
+// The [ByID] option enables querying for a single element with the matching CSS
 // ID, wrapping DOM.querySelector. ByID is similar to calling
 // document.querySelector('#' + ID) from within the browser.
 //
-// The ByQuery option enables querying for a single element using a CSS
+// The [ByQuery] option enables querying for a single element using a CSS
 // selector, wrapping DOM.querySelector. ByQuery is similar to calling
 // document.querySelector() from within the browser.
 //
-// The ByQueryAll option enables querying for elements using a CSS selector,
+// The [ByQueryAll] option enables querying for elements using a CSS selector,
 // wrapping DOM.querySelectorAll. ByQueryAll is similar to calling
 // document.querySelectorAll() from within the browser.
 //
-// The ByJSPath option enables querying for a single element using its "JS
+// The [ByJSPath] option enables querying for a single element using its "JS
 // Path" value, wrapping Runtime.evaluate. ByJSPath is similar to executing a
 // JavaScript snippet that returns a element from within the browser. ByJSPath
 // should be used only with trusted element queries, as it is passed directly
@@ -107,25 +107,25 @@ type Selector struct {
 //
 // # Node Options
 //
-// The NodeReady (default) option causes the query to wait until all element
+// The [NodeReady] (default) option causes the query to wait until all element
 // nodes matching the selector have been retrieved from the browser.
 //
-// The NodeVisible option causes the query to wait until all element nodes
+// The [NodeVisible] option causes the query to wait until all element nodes
 // matching the selector have been retrieved from the browser, and are visible.
 //
-// The NodeNotVisible option causes the query to wait until all element nodes
+// The [NodeNotVisible] option causes the query to wait until all element nodes
 // matching the selector have been retrieved from the browser, and are not
 // visible.
 //
-// The NodeEnabled option causes the query to wait until all element nodes
+// The [NodeEnabled] option causes the query to wait until all element nodes
 // matching the selector have been retrieved from the browser, and are enabled
 // (i.e., do not have a 'disabled' attribute).
 //
-// The NodeSelected option causes the query to wait until all element nodes
+// The [NodeSelected] option causes the query to wait until all element nodes
 // matching the selector have been retrieved from the browser, and are are
 // selected (i.e., has a 'selected' attribute).
 //
-// The NodeNotPresent option causes the query to wait until there are no
+// The [NodeNotPresent] option causes the query to wait until there are no
 // element nodes matching the selector.
 func Query(sel interface{}, opts ...QueryOption) QueryAction {
 	s := &Selector{

--- a/screenshot.go
+++ b/screenshot.go
@@ -24,10 +24,11 @@ import (
 // These CDP commands are not sent by chromedp. If it does not work as expected,
 // you can try to send those commands yourself.
 //
-// See CaptureScreenshot for capturing a screenshot of the browser viewport.
+// See [CaptureScreenshot] for capturing a screenshot of the browser viewport.
 //
-// See the 'screenshot' example in the https://github.com/chromedp/examples
-// project for an example of taking a screenshot of the entire page.
+// See [screenshot] for an example of taking a screenshot of the entire page.
+//
+// [screenshot]: https://github.com/chromedp/examples/tree/master/screenshot
 func Screenshot(sel interface{}, picbuf *[]byte, opts ...QueryOption) QueryAction {
 	if picbuf == nil {
 		panic("picbuf cannot be nil")
@@ -77,10 +78,11 @@ func Screenshot(sel interface{}, picbuf *[]byte, opts ...QueryOption) QueryActio
 // It's supposed to act the same as the command "Capture screenshot" in
 // Chrome. See the behavior notes of Screenshot for more information.
 //
-// See the Screenshot action to take a screenshot of a specific element.
+// See the [Screenshot] action to take a screenshot of a specific element.
 //
-// See the 'screenshot' example in the https://github.com/chromedp/examples
-// project for an example of taking a screenshot of the entire page.
+// See [screenshot] for an example of taking a screenshot of the entire page.
+//
+// [screenshot]: https://github.com/chromedp/examples/tree/master/screenshot
 func CaptureScreenshot(res *[]byte) Action {
 	if res == nil {
 		panic("res cannot be nil")


### PR DESCRIPTION
This PR improves documentation formatting on https://pkg.go.dev/github.com/chromedp/chromedp. See screenshots.

Godoc format applied:
```
// Lists:
//  - item 1
//  - item 2 
```

```
// The link to [kb] package or function [SomeFunc].
```

```
// External link to a [resource].
//
// [resource]: https://example.com
```

#### Package description

Before:
<img width="983" alt="image" src="https://user-images.githubusercontent.com/3228886/216920513-6c496008-8257-4dcb-b558-dcbe824eee97.png">

After:
<img width="926" alt="image" src="https://user-images.githubusercontent.com/3228886/216920590-db9fcb7d-d899-4dd9-9f81-9de6da0c5dad.png">

#### DisableGPU

Before:
<img width="970" alt="image" src="https://user-images.githubusercontent.com/3228886/216921707-75c34006-79f0-450e-af1d-00fe7f42dba7.png">

After:
<img width="956" alt="image" src="https://user-images.githubusercontent.com/3228886/216921791-547a2b50-ecec-48e8-a96b-bde4b9790f7f.png">

#### NewRemoteAllocator

Before:
<img width="1117" alt="image" src="https://user-images.githubusercontent.com/3228886/216921983-d1966257-952f-414d-93d1-00ccb59d9e5b.png">

After:
<img width="1107" alt="image" src="https://user-images.githubusercontent.com/3228886/216922057-a8d082d2-83ec-4975-9428-d53cb13dee78.png">

#### DefaultExecAllocatorOptions

Before:
<img width="992" alt="image" src="https://user-images.githubusercontent.com/3228886/216921375-7a0b08ac-91fe-4adf-b047-579a2d7d5a43.png">

After:
<img width="989" alt="image" src="https://user-images.githubusercontent.com/3228886/216921455-089ac614-2858-41db-aa01-2e36eea26f4f.png">

#### CaptureScreenshot

Before:
<img width="954" alt="image" src="https://user-images.githubusercontent.com/3228886/216922272-fbf14ab0-78bc-41b1-baef-18aef2a9c0de.png">

After:
<img width="956" alt="image" src="https://user-images.githubusercontent.com/3228886/216922371-5685a851-765d-495a-91a9-4173554605fd.png">

#### Browser.Process()

Before:
<img width="979" alt="image" src="https://user-images.githubusercontent.com/3228886/216921041-c2a8a7c4-44bd-496c-95c6-c2ddb7b70ee2.png">

After:
<img width="943" alt="image" src="https://user-images.githubusercontent.com/3228886/216921103-6488dbb6-4b9f-43d6-a82d-e02a5e2fcadd.png">
