### PR TITLE
correct typos in comments

### DIFF
--- a/allocate.go
+++ b/allocate.go
@@ -403,7 +403,7 @@ func Flag(name string, value interface{}) ExecAllocatorOption {
 
 // Env is a list of generic environment variables in the form NAME=value
 // to pass into the new Chrome process. These will be appended to the
-// environment of the golang process as retrieved by os.Environ.
+// environment of the Go process as retrieved by os.Environ.
 func Env(vars ...string) ExecAllocatorOption {
 	return func(a *ExecAllocator) {
 		a.initEnv = append(a.initEnv, vars...)

--- a/allocate_test.go
+++ b/allocate_test.go
@@ -309,7 +309,7 @@ func TestExecAllocatorMissingWebsocketAddr(t *testing.T) {
 	defer cancel()
 
 	// set the "s" flag to let "." match "\n"
-	// in Github Actions, the error text could be:
+	// in GitHub Actions, the error text could be:
 	// "chrome failed to start:\n/bin/bash: /etc/profile.d/env_vars.sh: Permission denied\nmkdir: cannot create directory ‘/run/user/1001’: Permission denied\n[0321/081807.491906:ERROR:headless_shell.cc(720)] Invalid devtools server address\n"
 	want := `failed to start`
 	got := fmt.Sprintf("%v", Run(ctx))

--- a/call.go
+++ b/call.go
@@ -7,11 +7,11 @@ import (
 	"github.com/chromedp/cdproto/runtime"
 )
 
-// CallAction are actions that calls a Javascript function using
+// CallAction are actions that calls a JavaScript function using
 // runtime.CallFunctionOn.
 type CallAction Action
 
-// CallFunctionOn is an action to call a Javascript function, unmarshaling
+// CallFunctionOn is an action to call a JavaScript function, unmarshaling
 // the result of the function to res.
 //
 // The handling of res is the same as that of Evaluate.

--- a/eval.go
+++ b/eval.go
@@ -8,11 +8,11 @@ import (
 	"github.com/chromedp/cdproto/runtime"
 )
 
-// EvaluateAction are actions that evaluate Javascript expressions using
+// EvaluateAction are actions that evaluate JavaScript expressions using
 // runtime.Evaluate.
 type EvaluateAction Action
 
-// Evaluate is an action to evaluate the Javascript expression, unmarshaling
+// Evaluate is an action to evaluate the JavaScript expression, unmarshaling
 // the result of the script evaluation to res.
 //
 // When res is nil, the script result will be ignored.
@@ -28,7 +28,7 @@ type EvaluateAction Action
 // runtime.ReleaseObjectGroup can be used to ask the browser to release
 // original objects.
 //
-// For all other cases, the result of the script will be returned "by value" (ie,
+// For all other cases, the result of the script will be returned "by value" (i.e.,
 // JSON-encoded), and subsequently an attempt will be made to json.Unmarshal
 // the script result to res. It returns an error if the script result is
 // "undefined" in this case.
@@ -95,18 +95,18 @@ func parseRemoteObject(v *runtime.RemoteObject, res interface{}) (undefined bool
 	return
 }
 
-// EvaluateAsDevTools is an action that evaluates a Javascript expression as
+// EvaluateAsDevTools is an action that evaluates a JavaScript expression as
 // Chrome DevTools would, evaluating the expression in the "console" context,
 // and making the Command Line API available to the script.
 //
 // See Evaluate for more information on how script expressions are evaluated.
 //
-// Note: this should not be used with untrusted Javascript.
+// Note: this should not be used with untrusted JavaScript.
 func EvaluateAsDevTools(expression string, res interface{}, opts ...EvaluateOption) EvaluateAction {
 	return Evaluate(expression, res, append(opts, EvalObjectGroup("console"), EvalWithCommandLineAPI)...)
 }
 
-// EvaluateOption is the type for Javascript evaluation options.
+// EvaluateOption is the type for JavaScript evaluation options.
 type EvaluateOption = func(*runtime.EvaluateParams) *runtime.EvaluateParams
 
 // EvalObjectGroup is a evaluate option to set the object group.
@@ -121,18 +121,18 @@ func EvalObjectGroup(objectGroup string) EvaluateOption {
 //
 // See Evaluate for more information on how evaluate actions work.
 //
-// Note: this should not be used with untrusted Javascript.
+// Note: this should not be used with untrusted JavaScript.
 func EvalWithCommandLineAPI(p *runtime.EvaluateParams) *runtime.EvaluateParams {
 	return p.WithIncludeCommandLineAPI(true)
 }
 
-// EvalIgnoreExceptions is a evaluate option that will cause Javascript
+// EvalIgnoreExceptions is a evaluate option that will cause JavaScript
 // evaluation to ignore exceptions.
 func EvalIgnoreExceptions(p *runtime.EvaluateParams) *runtime.EvaluateParams {
 	return p.WithSilent(true)
 }
 
-// EvalAsValue is a evaluate option that will cause the evaluated Javascript
+// EvalAsValue is a evaluate option that will cause the evaluated JavaScript
 // expression to encode the result of the expression as a JSON-encoded value.
 func EvalAsValue(p *runtime.EvaluateParams) *runtime.EvaluateParams {
 	return p.WithReturnByValue(true)

--- a/input.go
+++ b/input.go
@@ -23,7 +23,7 @@ func MouseEvent(typ input.MouseType, x, y float64, opts ...MouseOption) MouseAct
 	return p
 }
 
-// MouseClickXY is an action that sends a left mouse button click (ie,
+// MouseClickXY is an action that sends a left mouse button click (i.e.,
 // mousePressed and mouseReleased event) to the X, Y location.
 func MouseClickXY(x, y float64, opts ...MouseOption) MouseAction {
 	return ActionFunc(func(ctx context.Context) error {

--- a/js.go
+++ b/js.go
@@ -6,7 +6,7 @@ import (
 
 var (
 	// textJS is a javascript snippet that returns the innerText of the specified
-	// visible (ie, offsetWidth || offsetHeight || getClientRects().length ) element.
+	// visible (i.e., offsetWidth || offsetHeight || getClientRects().length ) element.
 	//go:embed js/text.js
 	textJS string
 

--- a/kb/gen.go
+++ b/kb/gen.go
@@ -472,7 +472,7 @@ const (
 	domCodeDataInc = chromiumSrc + "ui/events/keycodes/dom/dom_code_data.inc?format=TEXT"
 	// domKeyDataInc contains DomKey -> Key Name + unicode (non-printable)
 	domKeyDataInc = chromiumSrc + "ui/events/keycodes/dom/dom_key_data.inc?format=TEXT"
-	// keyboardCodesPosixH contains the scan code definitions for posix (ie native) keys.
+	// keyboardCodesPosixH contains the scan code definitions for posix (i.e. native) keys.
 	keyboardCodesPosixH = chromiumSrc + "ui/events/keycodes/keyboard_codes_posix.h?format=TEXT"
 	// keyboardCodesWinH contains the scan code definitions for windows keys.
 	keyboardCodesWinH = chromiumSrc + "ui/events/keycodes/keyboard_codes_win.h?format=TEXT"
@@ -503,7 +503,7 @@ type Key struct {
 	// 								false false | false true  | false true | false
 	Shift bool
 	// Print indicates whether or not the character is a printable character
-	// (ie, should a "char" event be generated).
+	// (i.e., should a "char" event be generated).
 	// 								true  true  | true  true  | true  true | false
 	Print bool
 }
@@ -552,7 +552,7 @@ type Key struct {
 	// 								false false | false true  | false true | false
 	Shift bool
 	// Print indicates whether or not the character is a printable character
-	// (ie, should a "char" event be generated).
+	// (i.e., should a "char" event be generated).
 	// 								true  true  | true  true  | true  true | false
 	Print bool
 }

--- a/kb/kb.go
+++ b/kb/kb.go
@@ -42,7 +42,7 @@ type Key struct {
 	// 								false false | false true  | false true | false
 	Shift bool
 	// Print indicates whether or not the character is a printable character
-	// (ie, should a "char" event be generated).
+	// (i.e., should a "char" event be generated).
 	// 								true  true  | true  true  | true  true | false
 	Print bool
 }

--- a/poll.go
+++ b/poll.go
@@ -9,7 +9,7 @@ import (
 	"github.com/chromedp/cdproto/runtime"
 )
 
-// PollAction are actions that will wait for a general Javascript predicate.
+// PollAction are actions that will wait for a general JavaScript predicate.
 //
 // See Poll for details on building poll tasks.
 type PollAction Action
@@ -82,8 +82,8 @@ func (p *pollTask) Do(ctx context.Context) error {
 	return err
 }
 
-// Poll is a poll action that will wait for a general Javascript predicate.
-// It builds the predicate from a Javascript expression.
+// Poll is a poll action that will wait for a general JavaScript predicate.
+// It builds the predicate from a JavaScript expression.
 //
 // This is a copy of puppeteer's page.waitForFunction.
 // see https://github.com/puppeteer/puppeteer/blob/v8.0.0/docs/api.md#pagewaitforfunctionpagefunction-options-args.
@@ -113,8 +113,8 @@ func Poll(expression string, res interface{}, opts ...PollOption) PollAction {
 	return poll(predicate, res, opts...)
 }
 
-// PollFunction is a poll action that will wait for a general Javascript predicate.
-// It builds the predicate from a Javascript function.
+// PollFunction is a poll action that will wait for a general JavaScript predicate.
+// It builds the predicate from a JavaScript function.
 //
 // See Poll for details on building poll tasks.
 func PollFunction(pageFunction string, res interface{}, opts ...PollOption) PollAction {

--- a/query.go
+++ b/query.go
@@ -99,7 +99,7 @@ type Selector struct {
 //
 // The ByJSPath option enables querying for a single element using its "JS
 // Path" value, wrapping Runtime.evaluate. ByJSPath is similar to executing a
-// Javascript snippet that returns a element from within the browser. ByJSPath
+// JavaScript snippet that returns a element from within the browser. ByJSPath
 // should be used only with trusted element queries, as it is passed directly
 // to Runtime.evaluate, and no attempt is made to sanitize the query. Useful
 // for querying DOM elements that cannot be retrieved using other By* funcs,
@@ -119,11 +119,11 @@ type Selector struct {
 //
 // The NodeEnabled option causes the query to wait until all element nodes
 // matching the selector have been retrieved from the browser, and are enabled
-// (ie, do not have a 'disabled' attribute).
+// (i.e., do not have a 'disabled' attribute).
 //
 // The NodeSelected option causes the query to wait until all element nodes
 // matching the selector have been retrieved from the browser, and are are
-// selected (ie, has a 'selected' attribute).
+// selected (i.e., has a 'selected' attribute).
 //
 // The NodeNotPresent option causes the query to wait until there are no
 // element nodes matching the selector.
@@ -496,7 +496,7 @@ func NodeNotVisible(s *Selector) {
 }
 
 // NodeEnabled is an element query option to wait until all queried element
-// nodes have been sent by the browser and are enabled (ie, do not have a
+// nodes have been sent by the browser and are enabled (i.e., do not have a
 // 'disabled' attribute).
 func NodeEnabled(s *Selector) {
 	WaitFunc(s.waitReady(func(ctx context.Context, execCtx runtime.ExecutionContextID, n *cdp.Node) error {
@@ -514,7 +514,7 @@ func NodeEnabled(s *Selector) {
 }
 
 // NodeSelected is an element query option to wait until all queried element
-// nodes have been sent by the browser and are selected (ie, has 'selected'
+// nodes have been sent by the browser and are selected (i.e., has 'selected'
 // attribute).
 func NodeSelected(s *Selector) {
 	WaitFunc(s.waitReady(func(ctx context.Context, execCtx runtime.ExecutionContextID, n *cdp.Node) error {
@@ -575,7 +575,7 @@ func After(f func(context.Context, runtime.ExecutionContextID, ...*cdp.Node) err
 }
 
 // WaitReady is an element query action that waits until the element matching
-// the selector is ready (ie, has been "loaded").
+// the selector is ready (i.e., has been "loaded").
 func WaitReady(sel interface{}, opts ...QueryOption) QueryAction {
 	return Query(sel, opts...)
 }
@@ -593,13 +593,13 @@ func WaitNotVisible(sel interface{}, opts ...QueryOption) QueryAction {
 }
 
 // WaitEnabled is an element query action that waits until the element matching
-// the selector is enabled (ie, does not have attribute 'disabled').
+// the selector is enabled (i.e., does not have attribute 'disabled').
 func WaitEnabled(sel interface{}, opts ...QueryOption) QueryAction {
 	return Query(sel, append(opts, NodeEnabled)...)
 }
 
 // WaitSelected is an element query action that waits until the element
-// matching the selector is selected (ie, has attribute 'selected').
+// matching the selector is selected (i.e., has attribute 'selected').
 func WaitSelected(sel interface{}, opts ...QueryOption) QueryAction {
 	return Query(sel, append(opts, NodeSelected)...)
 }
@@ -782,10 +782,10 @@ func Clear(sel interface{}, opts ...QueryOption) QueryAction {
 	}, opts...)
 }
 
-// Value is an element query action that retrieves the Javascript value field of the
+// Value is an element query action that retrieves the JavaScript value field of the
 // first element node matching the selector.
 //
-// Useful for retrieving an element's Javascript value, namely form, input,
+// Useful for retrieving an element's JavaScript value, namely form, input,
 // textarea, select, or any other element with a '.value' field.
 func Value(sel interface{}, value *string, opts ...QueryOption) QueryAction {
 	if value == nil {
@@ -795,10 +795,10 @@ func Value(sel interface{}, value *string, opts ...QueryOption) QueryAction {
 	return JavascriptAttribute(sel, "value", value, opts...)
 }
 
-// SetValue is an element query action that sets the Javascript value of the first
+// SetValue is an element query action that sets the JavaScript value of the first
 // element node matching the selector.
 //
-// Useful for setting an element's Javascript value, namely form, input,
+// Useful for setting an element's JavaScript value, namely form, input,
 // textarea, select, or other element with a '.value' field.
 func SetValue(sel interface{}, value string, opts ...QueryOption) QueryAction {
 	return SetJavascriptAttribute(sel, "value", value, opts...)
@@ -935,7 +935,7 @@ func RemoveAttribute(sel interface{}, name string, opts ...QueryOption) QueryAct
 	}, opts...)
 }
 
-// JavascriptAttribute is an element query action that retrieves the Javascript
+// JavascriptAttribute is an element query action that retrieves the JavaScript
 // attribute for the first element node matching the selector.
 func JavascriptAttribute(sel interface{}, name string, res interface{}, opts ...QueryOption) QueryAction {
 	if res == nil {
@@ -954,7 +954,7 @@ func JavascriptAttribute(sel interface{}, name string, res interface{}, opts ...
 	}, opts...)
 }
 
-// SetJavascriptAttribute is an element query action that sets the Javascript attribute
+// SetJavascriptAttribute is an element query action that sets the JavaScript attribute
 // for the first element node matching the selector.
 func SetJavascriptAttribute(sel interface{}, name, value string, opts ...QueryOption) QueryAction {
 	return QueryAfter(sel, func(ctx context.Context, execCtx runtime.ExecutionContextID, nodes ...*cdp.Node) error {
@@ -1053,7 +1053,7 @@ func SendKeys(sel interface{}, v string, opts ...QueryOption) QueryAction {
 	}, append(opts, NodeVisible)...)
 }
 
-// SetUploadFiles is an element query action that sets the files to upload (ie, for a
+// SetUploadFiles is an element query action that sets the files to upload (i.e., for a
 // input[type="file"] node) for the first element node matching the selector.
 func SetUploadFiles(sel interface{}, files []string, opts ...QueryOption) QueryAction {
 	return QueryAfter(sel, func(ctx context.Context, execCtx runtime.ExecutionContextID, nodes ...*cdp.Node) error {


### PR DESCRIPTION
This PR fixes the following words:

- Javascript -> JavaScript
- ie -> i.e.
- golang -> Go
- Github -> GitHub