### PR TITLE
Correct typo and grammar issues  in comments

### DIFF
--- a/allocate.go
+++ b/allocate.go
@@ -437,7 +437,7 @@ func ProxyServer(proxy string) ExecAllocatorOption {
 }
 
 // IgnoreCertErrors is the command line option to ignore certificate-related
-// errors. This options is useful when you need to access an HTTPS website
+// errors. This option is useful when you need to access an HTTPS website
 // through a proxy.
 func IgnoreCertErrors(a *ExecAllocator) {
 	Flag("ignore-certificate-errors", true)(a)

--- a/chromedp.go
+++ b/chromedp.go
@@ -574,7 +574,7 @@ func responseAction(resp **network.Response, actions ...Action) Action {
 			}
 
 			// If the ctx parameter was cancelled by the caller (or
-			// by a timeout etc) the select will race between
+			// by a timeout etc.) the select will race between
 			// lctx.Done and ctx.Done, since lctx is a sub-context
 			// of ctx. So we can't return nil here, as otherwise
 			// that race would mean that we would drop 50% of the
@@ -608,7 +608,7 @@ type Action interface {
 	Do(context.Context) error
 }
 
-// ActionFunc is a adapter to allow the use of ordinary func's as an Action.
+// ActionFunc is an adapter to allow the use of ordinary func's as an Action.
 type ActionFunc func(context.Context) error
 
 // Do executes the func f using the provided context and frame handler.

--- a/chromedp_test.go
+++ b/chromedp_test.go
@@ -116,7 +116,7 @@ func testAllocate(tb testing.TB, name string) (context.Context, context.CancelFu
 	// each test gives a huge speed-up.
 	ctx, _ := NewContext(browserCtx)
 
-	// Only navigate if we want an html file name, otherwise leave the blank page.
+	// Only navigate if we want an HTML file name, otherwise leave the blank page.
 	if name != "" {
 		if err := Run(ctx, Navigate(testdataDir+"/"+name)); err != nil {
 			tb.Fatal(err)

--- a/eval.go
+++ b/eval.go
@@ -109,7 +109,7 @@ func EvaluateAsDevTools(expression string, res interface{}, opts ...EvaluateOpti
 // EvaluateOption is the type for JavaScript evaluation options.
 type EvaluateOption = func(*runtime.EvaluateParams) *runtime.EvaluateParams
 
-// EvalObjectGroup is a evaluate option to set the object group.
+// EvalObjectGroup is an evaluate option to set the object group.
 func EvalObjectGroup(objectGroup string) EvaluateOption {
 	return func(p *runtime.EvaluateParams) *runtime.EvaluateParams {
 		return p.WithObjectGroup(objectGroup)
@@ -126,13 +126,13 @@ func EvalWithCommandLineAPI(p *runtime.EvaluateParams) *runtime.EvaluateParams {
 	return p.WithIncludeCommandLineAPI(true)
 }
 
-// EvalIgnoreExceptions is a evaluate option that will cause JavaScript
+// EvalIgnoreExceptions is an evaluate option that will cause JavaScript
 // evaluation to ignore exceptions.
 func EvalIgnoreExceptions(p *runtime.EvaluateParams) *runtime.EvaluateParams {
 	return p.WithSilent(true)
 }
 
-// EvalAsValue is a evaluate option that will cause the evaluated JavaScript
+// EvalAsValue is an evaluate option that will cause the evaluated JavaScript
 // expression to encode the result of the expression as a JSON-encoded value.
 func EvalAsValue(p *runtime.EvaluateParams) *runtime.EvaluateParams {
 	return p.WithReturnByValue(true)

--- a/input.go
+++ b/input.go
@@ -180,7 +180,7 @@ func KeyEvent(keys string, opts ...KeyOption) KeyAction {
 	})
 }
 
-// KeyEventNode is a key action that dispatches a key event on a element node.
+// KeyEventNode is a key action that dispatches a key event on an element node.
 func KeyEventNode(n *cdp.Node, keys string, opts ...KeyOption) KeyAction {
 	return ActionFunc(func(ctx context.Context) error {
 		err := dom.Focus().WithNodeID(n.NodeID).Do(ctx)

--- a/js.go
+++ b/js.go
@@ -53,7 +53,7 @@ var (
 	// waitForPredicatePageFunction is a javascript snippet that runs the polling in the
 	// browser. It's copied from puppeteer. See
 	// https://github.com/puppeteer/puppeteer/blob/669f04a7a6e96cc8353a8cb152898edbc25e7c15/src/common/DOMWorld.ts#L870-L944
-	// It's modified to make mutation polling respect timeout even when there is not DOM mutation.
+	// It's modified to make mutation polling respect timeout even when there is not a DOM mutation.
 	//go:embed js/waitForPredicatePageFunction.js
 	waitForPredicatePageFunction string
 )

--- a/kb/gen.go
+++ b/kb/gen.go
@@ -345,14 +345,14 @@ func loadScanCodes(domCodeMap, domKeyMap map[string][]string, layoutBuf []byte) 
 
 var defineRE = regexp.MustCompile(`(?m)^#define\s+(.+?)\s+([0-9A-Fx]+)`)
 
-// loadPosixWinKeyboardCodes loads the native and windows keyboard scan codes
+// loadPosixWinKeyboardCodes loads the native and Windows keyboard scan codes
 // mapped to the DOM key.
 func loadPosixWinKeyboardCodes() (map[string][]int64, error) {
 	lookup := map[string]string{
 		// mac alias
 		"VKEY_LWIN": "0x5B",
 		// no idea where these are defined in chromium code base (assuming in
-		// windows headers)
+		// Windows headers)
 		//
 		// manually added here as pulled from various online docs
 		"VK_CANCEL":       "0x03",
@@ -364,7 +364,7 @@ func loadPosixWinKeyboardCodes() (map[string][]int64, error) {
 		"VK_OEM_BACKTAB":  "0xF5",
 		"VK_OEM_AX":       "0xE1",
 	}
-	// load windows key lookups
+	// load Windows key lookups
 	buf, err := grab(windowsKeyboardCodesH)
 	if err != nil {
 		return nil, err
@@ -474,9 +474,9 @@ const (
 	domKeyDataInc = chromiumSrc + "ui/events/keycodes/dom/dom_key_data.inc?format=TEXT"
 	// keyboardCodesPosixH contains the scan code definitions for posix (i.e. native) keys.
 	keyboardCodesPosixH = chromiumSrc + "ui/events/keycodes/keyboard_codes_posix.h?format=TEXT"
-	// keyboardCodesWinH contains the scan code definitions for windows keys.
+	// keyboardCodesWinH contains the scan code definitions for Windows keys.
 	keyboardCodesWinH = chromiumSrc + "ui/events/keycodes/keyboard_codes_win.h?format=TEXT"
-	// windowsKeyboardCodesH contains the actual #defs for windows.
+	// windowsKeyboardCodesH contains the actual #defs for Windows.
 	windowsKeyboardCodesH = chromiumSrc + "third_party/blink/renderer/platform/windows_keyboard_codes.h?format=TEXT"
 )
 
@@ -496,7 +496,7 @@ type Key struct {
 	// Native is the native scan code.
 	// 								0x13  0x13  | 0xbc  0xbc  | 0x61  0x41 | 0x00ae
 	Native int64
-	// Windows is the windows scan code.
+	// Windows is the Windows scan code.
 	// 								0x13  0x13  | 0xbc  0xbc  | 0x61  0x41 | 0xe024
 	Windows int64
 	// Shift indicates whether or not the Shift modifier should be sent.
@@ -549,7 +549,7 @@ type Key struct {
 	Unmodified string
 	// Native is the native scan code.
 	Native int64
-	// Windows is the windows scan code.
+	// Windows is the Windows scan code.
 	Windows int64
 	// Shift indicates whether or not the Shift modifier should be sent.
 	Shift bool

--- a/kb/kb.go
+++ b/kb/kb.go
@@ -39,7 +39,7 @@ type Key struct {
 	Unmodified string
 	// Native is the native scan code.
 	Native int64
-	// Windows is the windows scan code.
+	// Windows is the Windows scan code.
 	Windows int64
 	// Shift indicates whether or not the Shift modifier should be sent.
 	Shift bool

--- a/nav_test.go
+++ b/nav_test.go
@@ -351,7 +351,7 @@ func TestNavigateWhileLoading(t *testing.T) {
 			// events. See https://github.com/chromedp/chromedp/issues/1080.
 			//
 			// The implementation of responseAction() is buggy in this case.
-			// But it's hard to fix it since there is not way to tell whether
+			// But it's hard to fix it since there is not a way to tell whether
 			// the events are from the first navigate.
 			//
 			// I (ZekeLu) will just deflake this test by making sure the second

--- a/poll.go
+++ b/poll.go
@@ -14,7 +14,7 @@ import (
 // See [Poll] for details on building poll tasks.
 type PollAction Action
 
-// pollTask holds information pertaining to an poll task.
+// pollTask holds information pertaining to a poll task.
 //
 // See Poll for details on building poll tasks.
 type pollTask struct {
@@ -139,7 +139,7 @@ func poll(predicate string, res interface{}, opts ...PollOption) PollAction {
 	return p
 }
 
-// PollOption is an poll task option.
+// PollOption is a poll task option.
 type PollOption = func(task *pollTask)
 
 // WithPollingInterval makes it to poll the predicate with the specified interval.

--- a/query.go
+++ b/query.go
@@ -99,7 +99,7 @@ type Selector struct {
 //
 // The [ByJSPath] option enables querying for a single element using its "JS
 // Path" value, wrapping Runtime.evaluate. ByJSPath is similar to executing a
-// JavaScript snippet that returns a element from within the browser. ByJSPath
+// JavaScript snippet that returns an element from within the browser. ByJSPath
 // should be used only with trusted element queries, as it is passed directly
 // to Runtime.evaluate, and no attempt is made to sanitize the query. Useful
 // for querying DOM elements that cannot be retrieved using other By* funcs,
@@ -122,7 +122,7 @@ type Selector struct {
 // (i.e., do not have a 'disabled' attribute).
 //
 // The [NodeSelected] option causes the query to wait until all element nodes
-// matching the selector have been retrieved from the browser, and are are
+// matching the selector have been retrieved from the browser, and are
 // selected (i.e., has a 'selected' attribute).
 //
 // The [NodeNotPresent] option causes the query to wait until there are no
@@ -1023,7 +1023,7 @@ func DoubleClick(sel interface{}, opts ...QueryOption) QueryAction {
 //
 // See the [keys] for a complete example on how to use SendKeys.
 //
-// Note: when the element query matches a input[type="file"] node, then
+// Note: when the element query matches an input[type="file"] node, then
 // dom.SetFileInputFiles is used to set the upload path of the input node to v.
 //
 // [keys]: https://github.com/chromedp/examples/tree/master/keys


### PR DESCRIPTION
- This options -> This option
- etc -> etc.
- an html file -> a html file
- a evaluate option -> an evaluate option
- windows -> Windows