### PR TITLE
make parseRemoteObject handle undefined/null reasonably

### DIFF
--- a/call.go
+++ b/call.go
@@ -28,7 +28,7 @@ func CallFunctionOn(functionDeclaration string, res interface{}, opt CallOption,
 	})
 }
 
-func callFunctionOn(ctx context.Context, functionDeclaration string, res interface{}, opt CallOption, args ...interface{}) (bool, error) {
+func callFunctionOn(ctx context.Context, functionDeclaration string, res interface{}, opt CallOption, args ...interface{}) (*runtime.RemoteObject, error) {
 	// set up parameters
 	p := runtime.CallFunctionOn(functionDeclaration).
 		WithSilent(true)
@@ -51,7 +51,7 @@ func callFunctionOn(ctx context.Context, functionDeclaration string, res interfa
 			ea.append(arg)
 		}
 		if ea.err != nil {
-			return false, ea.err
+			return nil, ea.err
 		}
 		p = p.WithArguments(ea.args)
 	}
@@ -59,13 +59,13 @@ func callFunctionOn(ctx context.Context, functionDeclaration string, res interfa
 	// call
 	v, exp, err := p.Do(ctx)
 	if err != nil {
-		return false, err
+		return nil, err
 	}
 	if exp != nil {
-		return false, exp
+		return nil, exp
 	}
 
-	return parseRemoteObject(v, res)
+	return v, parseRemoteObject(v, res)
 }
 
 // CallOption is a function to modify the runtime.CallFunctionOnParams

--- a/chromedp_test.go
+++ b/chromedp_test.go
@@ -1075,7 +1075,7 @@ func TestWebGL(t *testing.T) {
 		Screenshot(`#c`, &buf, ByQuery),
 	); err != nil {
 		if errors.Is(err, ErrPollingTimeout) {
-			t.Fatal("The cube it not rendered in 2s.")
+			t.Fatal("The cube is not rendered in 2s.")
 		} else {
 			t.Fatal(err)
 		}

--- a/errors.go
+++ b/errors.go
@@ -48,4 +48,10 @@ const (
 
 	// ErrPollingTimeout is the error that the timeout reached before the pageFunction returns a truthy value.
 	ErrPollingTimeout Error = "waiting for function failed: timeout"
+
+	// ErrJSUndefined is the error that the type of RemoteObject is "undefined".
+	ErrJSUndefined Error = "encountered an undefined value"
+
+	// ErrJSNull is the error that the value of RemoteObject is null.
+	ErrJSNull Error = "encountered a null value"
 )

--- a/example_test.go
+++ b/example_test.go
@@ -593,3 +593,91 @@ func ExampleFullScreenshot() {
 	// Output:
 	// wrote fullScreenshot.jpeg
 }
+
+func ExampleEvaluate() {
+	ctx, cancel := chromedp.NewContext(context.Background())
+	defer cancel()
+
+	// Ignore the result:
+	{
+		if err := chromedp.Run(ctx,
+			chromedp.Evaluate(`window.scrollTo(0, 100)`, nil),
+		); err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	// Receive a primary value:
+	{
+		var sum int
+		if err := chromedp.Run(ctx,
+			chromedp.Evaluate(`1+2`, &sum),
+		); err != nil {
+			log.Fatal(err)
+		}
+		fmt.Println(sum)
+	}
+
+	// ErrJSUndefined:
+	{
+		var val int
+		if err := chromedp.Run(ctx,
+			chromedp.Evaluate(`undefined`, &val),
+		); err != nil {
+			fmt.Println(err)
+		}
+	}
+
+	// ErrJSNull:
+	{
+		var val int
+		if err := chromedp.Run(ctx,
+			chromedp.Evaluate(`null`, &val),
+		); err != nil {
+			fmt.Println(err)
+		}
+	}
+
+	// Accept undefined/nil result:
+	{
+		var val *int
+		if err := chromedp.Run(ctx,
+			chromedp.Evaluate(`undefined`, &val),
+		); err != nil {
+			log.Fatal(err)
+		}
+		fmt.Println(val)
+	}
+
+	// Receive the raw bytes:
+	{
+		var buf []byte
+		if err := chromedp.Run(ctx,
+			chromedp.Evaluate(`alert`, &buf),
+		); err != nil {
+			log.Fatal(err)
+		}
+		fmt.Printf("%s\n", buf)
+	}
+
+	// Receive the RemoteObject:
+	{
+		var res *runtime.RemoteObject
+		if err := chromedp.Run(ctx,
+			chromedp.Evaluate(`alert`, &res),
+		); err != nil {
+			log.Fatal(err)
+		}
+		if res.ObjectID != "" {
+			fmt.Println("objectId is present")
+		}
+	}
+
+	// Output:
+	// 3
+	// encountered an undefined value
+	// encountered a null value
+	// <nil>
+	// {}
+	// objectId is present
+}

--- a/poll.go
+++ b/poll.go
@@ -66,7 +66,7 @@ func (p *pollTask) Do(ctx context.Context) error {
 	args = append(args, p.timeout.Milliseconds())
 	args = append(args, p.args...)
 
-	undefined, err := callFunctionOn(ctx, waitForPredicatePageFunction, p.res,
+	r, err := callFunctionOn(ctx, waitForPredicatePageFunction, p.res,
 		func(p *runtime.CallFunctionOnParams) *runtime.CallFunctionOnParams {
 			return p.WithExecutionContextID(execCtx).
 				WithAwaitPromise(true).
@@ -75,7 +75,7 @@ func (p *pollTask) Do(ctx context.Context) error {
 		args...,
 	)
 
-	if undefined {
+	if r != nil && r.Type == "undefined" {
 		return ErrPollingTimeout
 	}
 


### PR DESCRIPTION
When the value that `res` points to is a pointer, it should accept `undefined` or  `null`.

```go
	// ErrJSUndefined:
	{
		var val int
		if err := chromedp.Run(ctx,
			chromedp.Evaluate(`undefined`, &val),
		); err != nil {
			fmt.Println(err)
		}
	}

	// ErrJSNull:
	{
		var val int
		if err := chromedp.Run(ctx,
			chromedp.Evaluate(`null`, &val),
		); err != nil {
			fmt.Println(err)
		}
	}

	// Accept undefined/nil result:
	{
		var val *int
		if err := chromedp.Run(ctx,
			chromedp.Evaluate(`undefined`, &val),
		); err != nil {
			log.Fatal(err)
		}
		fmt.Println(val)
	}
```

Fixes #1259.