### PR TITLE
Cleanup unused logic in chromedp_test

### DIFF
--- a/chromedp_test.go
+++ b/chromedp_test.go
@@ -52,11 +52,6 @@ func init() {
 	}
 	testdataDir = "file://" + path.Join(wd, "testdata")
 
-	allocTempDir, err = os.MkdirTemp("", "chromedp-test")
-	if err != nil {
-		panic(fmt.Sprintf("could not create temp directory: %v", err))
-	}
-
 	// Disabling the GPU helps portability with some systems like Travis,
 	// and can slightly speed up the tests on other systems.
 	allocOpts = append(allocOpts, DisableGPU)
@@ -90,13 +85,6 @@ func TestMain(m *testing.M) {
 
 	code := m.Run()
 	cancel()
-
-	if infos, _ := os.ReadDir(allocTempDir); len(infos) > 0 {
-		os.RemoveAll(allocTempDir)
-		panic(fmt.Sprintf("leaked %d temporary dirs under %s", len(infos), allocTempDir))
-	} else {
-		os.Remove(allocTempDir)
-	}
 
 	os.Exit(code)
 }


### PR DESCRIPTION
After [the commit](https://github.com/chromedp/chromedp/commit/5f2e7b81e6ccc613ab26cc174efca0257b818988#diff-3765a2cc18b7983992eb9ccd733ea396e55315100b54bb7f4dfcd655c23c3f4aR674) the logic about checking `allocTempDir` for leaking became useless. This PR removes it.