### PR TITLE
introduce BrowserContext support

### DIFF
--- a/chromedp.go
+++ b/chromedp.go
@@ -49,6 +49,28 @@ type Context struct {
 	// unused page target, or create a new one.
 	targetID target.ID
 
+	// createBrowserContextParams is set up by WithNewBrowserContext. It is used
+	// to create a new BrowserContext.
+	createBrowserContextParams *target.CreateBrowserContextParams
+
+	// browserContextOwner indicates whether this context is a BrowserContext
+	// owner. The owner is responsible for disposing the BrowserContext once
+	// the context is done.
+	browserContextOwner bool
+
+	// BrowserContextID is set up by WithExistingBrowserContext.
+	//
+	// Otherwise, BrowserContextID holds a non-empty value in the following cases:
+	//
+	// 1. if the context is created with the WithNewBrowserContext option, a new
+	// BrowserContext is created on its first run, and BrowserContextID holds
+	// the id of that new BrowserContext;
+	//
+	// 2. if the context is not created with the WithTargetID option, and its
+	// parent context has a non-empty BrowserContextID, this context's
+	// BrowserContextID is copied from the parent context.
+	BrowserContextID cdp.BrowserContextID
+
 	browserListeners []cancelableListener
 	targetListeners  []cancelableListener
 
@@ -73,7 +95,7 @@ type Context struct {
 	closedTarget sync.WaitGroup
 
 	// allocated is closed when an allocated browser completely stops. If no
-	// browser needs to be allocated, the channel is simply not initialised
+	// browser needs to be allocated, the channel is simply not initialized
 	// and remains nil.
 	allocated chan struct{}
 
@@ -101,9 +123,11 @@ func NewContext(parent context.Context, opts ...ContextOption) (context.Context,
 	ctx, cancel := context.WithCancel(parent)
 
 	c := &Context{cancel: cancel, first: true}
+	var parentBrowserContextID cdp.BrowserContextID
 	if pc := FromContext(parent); pc != nil {
 		c.Allocator = pc.Allocator
 		c.Browser = pc.Browser
+		parentBrowserContextID = pc.BrowserContextID
 		// don't inherit Target, so that NewContext can be used to
 		// create a new tab on the same browser.
 
@@ -123,6 +147,23 @@ func NewContext(parent context.Context, opts ...ContextOption) (context.Context,
 	for _, o := range opts {
 		o(c)
 	}
+	if c.createBrowserContextParams != nil && c.BrowserContextID != "" {
+		panic("WithExistingBrowserContext can not be used when WithNewBrowserContext is specified")
+	}
+	if c.targetID == "" {
+		if c.BrowserContextID == "" {
+			// Inherit BrowserContextID from its parent context.
+			c.BrowserContextID = parentBrowserContextID
+		}
+	} else {
+		if c.createBrowserContextParams != nil {
+			panic("WithNewBrowserContext can not be used when WithTargetID is specified")
+		}
+		if c.BrowserContextID != "" {
+			panic("WithExistingBrowserContext can not be used when WithTargetID is specified")
+		}
+	}
+
 	if c.Allocator == nil {
 		c.Allocator = setupExecAllocator(DefaultExecAllocatorOptions[:]...)
 	}
@@ -148,15 +189,22 @@ func NewContext(parent context.Context, opts ...ContextOption) (context.Context,
 		// We need a new context, as ctx is cancelled; use a 1s timeout.
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 		defer cancel()
+		browserExecutor := cdp.WithExecutor(ctx, c.Browser)
 		if id := c.Target.SessionID; id != "" {
 			action := target.DetachFromTarget().WithSessionID(id)
-			if err := action.Do(cdp.WithExecutor(ctx, c.Browser)); c.cancelErr == nil && err != nil {
+			if err := action.Do(browserExecutor); c.cancelErr == nil && err != nil {
 				c.cancelErr = err
 			}
 		}
 		if id := c.Target.TargetID; id != "" {
 			action := target.CloseTarget(id)
-			if err := action.Do(cdp.WithExecutor(ctx, c.Browser)); c.cancelErr == nil && err != nil {
+			if err := action.Do(browserExecutor); c.cancelErr == nil && err != nil {
+				c.cancelErr = err
+			}
+		}
+		if c.browserContextOwner {
+			action := target.DisposeBrowserContext(c.BrowserContextID)
+			if err := action.Do(browserExecutor); c.cancelErr == nil && err != nil {
 				c.cancelErr = err
 			}
 		}
@@ -263,6 +311,15 @@ func initContextBrowser(ctx context.Context) (*Context, error) {
 // Note that the first time Run is called on a context, a browser will be
 // allocated via Allocator. Thus, it's generally a bad idea to use a context
 // timeout on the first Run call, as it will stop the entire browser.
+//
+// Also note that the actions are run with the Target executor. In the case that
+// a Browser executor is required, the action can be written like this:
+//
+//	err := chromedp.Run(ctx, chromedp.ActionFunc(func(ctx context.Context) error {
+//		c := chromedp.FromContext(ctx)
+//		id, err := target.CreateBrowserContext().Do(cdp.WithExecutor(ctx, c.Browser))
+//		return err
+//	}))
 func Run(ctx context.Context, actions ...Action) error {
 	c, err := initContextBrowser(ctx)
 	if err != nil {
@@ -300,7 +357,16 @@ func (c *Context) newTarget(ctx context.Context) error {
 	}
 	if !c.first {
 		var err error
-		c.targetID, err = target.CreateTarget("about:blank").Do(cdp.WithExecutor(ctx, c.Browser))
+		browserExecutor := cdp.WithExecutor(ctx, c.Browser)
+		if c.createBrowserContextParams != nil {
+			c.BrowserContextID, err = c.createBrowserContextParams.Do(browserExecutor)
+			if err != nil {
+				return err
+			}
+			c.browserContextOwner = true
+			c.createBrowserContextParams = nil
+		}
+		c.targetID, err = target.CreateTarget("about:blank").WithBrowserContextID(c.BrowserContextID).Do(browserExecutor)
 		if err != nil {
 			return err
 		}
@@ -409,6 +475,38 @@ type ContextOption = func(*Context)
 // of creating a new one.
 func WithTargetID(id target.ID) ContextOption {
 	return func(c *Context) { c.targetID = id }
+}
+
+// CreateBrowserContextOption is a BrowserContext creation options.
+type CreateBrowserContextOption = func(*target.CreateBrowserContextParams) *target.CreateBrowserContextParams
+
+// WithNewBrowserContext sets up a context to create a new BrowserContext, and
+// create a new target in this BrowserContext. A child context will create its
+// target in this BrowserContext too, unless it's set up with other options.
+// The new BrowserContext will be disposed when the context is done.
+func WithNewBrowserContext(options ...CreateBrowserContextOption) ContextOption {
+	return func(c *Context) {
+		if c.first {
+			panic("WithNewBrowserContext can not be used before Browser is initialized")
+		}
+
+		params := target.CreateBrowserContext().WithDisposeOnDetach(true)
+		for _, o := range options {
+			params = o(params)
+		}
+		c.createBrowserContextParams = params
+	}
+}
+
+// WithExistingBrowserContext sets up a context to create a new target in the
+// specified browser context.
+func WithExistingBrowserContext(id cdp.BrowserContextID) ContextOption {
+	return func(c *Context) {
+		if c.first {
+			panic("WithExistingBrowserContext can not be used before Browser is initialized")
+		}
+		c.BrowserContextID = id
+	}
 }
 
 // WithLogf is a shortcut for WithBrowserOption(WithBrowserLogf(f)).

--- a/chromedp_test.go
+++ b/chromedp_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/chromedp/cdproto/runtime"
 	"github.com/chromedp/cdproto/target"
 	"github.com/ledongthuc/pdf"
+	"golang.org/x/exp/slices"
 )
 
 var (
@@ -179,7 +180,7 @@ func BenchmarkTabNavigate(b *testing.B) {
 	})
 }
 
-// checkPages fatals if the browser behind the chromedp context has an
+// checkTargets fatals if the browser behind the chromedp context has an
 // unexpected number of pages (tabs).
 func checkTargets(tb testing.TB, ctx context.Context, want int) {
 	tb.Helper()
@@ -583,6 +584,338 @@ func TestLogOptions(t *testing.T) {
 	}
 }
 
+func TestBrowserContext(t *testing.T) {
+	ctx, cancel := testAllocate(t, "child1.html")
+	defer cancel()
+	// There is not a dedicated cdp command to get the default browser context.
+	// Our workaround is to get it from a target which is created without the
+	// "browserContextId" parameter.
+	defaultBrowserContextID := getBrowserContext(t, ctx)
+
+	// Prepare 2 browser contexts to be used later.
+	rootCtx1, cancel := NewContext(browserCtx, WithNewBrowserContext())
+	defer cancel()
+	if err := Run(rootCtx1); err != nil {
+		t.Fatal(err)
+	}
+	rootBrowserContextID1 := FromContext(rootCtx1).BrowserContextID
+
+	rootCtx2, cancel := NewContext(browserCtx, WithNewBrowserContext())
+	defer cancel()
+	if err := Run(rootCtx2); err != nil {
+		t.Fatal(err)
+	}
+	rootBrowserContextID2 := FromContext(rootCtx2).BrowserContextID
+
+	tests := []struct {
+		name         string
+		arrange      func(t *testing.T) (context.Context, context.CancelFunc, cdp.BrowserContextID)
+		wantDisposed bool
+		wantPanic    string
+	}{
+		{
+			name: "default",
+			arrange: func(t *testing.T) (context.Context, context.CancelFunc, cdp.BrowserContextID) {
+				ctx, cancel := NewContext(browserCtx)
+				if err := Run(ctx); err != nil {
+					t.Fatal(err)
+				}
+				return ctx, cancel, defaultBrowserContextID
+			},
+			wantDisposed: false,
+			wantPanic:    "",
+		},
+		{
+			name: "new",
+			arrange: func(t *testing.T) (context.Context, context.CancelFunc, cdp.BrowserContextID) {
+				ctx, cancel := NewContext(browserCtx, WithNewBrowserContext())
+				if err := Run(ctx); err != nil {
+					t.Fatal(err)
+				}
+				c := FromContext(ctx)
+				return ctx, cancel, c.BrowserContextID
+			},
+			wantDisposed: true,
+			wantPanic:    "",
+		},
+		{
+			name: "existing",
+			arrange: func(t *testing.T) (context.Context, context.CancelFunc, cdp.BrowserContextID) {
+				ctx, cancel := NewContext(browserCtx, WithExistingBrowserContext(rootBrowserContextID1))
+				if err := Run(ctx); err != nil {
+					t.Fatal(err)
+				}
+				return ctx, cancel, rootBrowserContextID1
+			},
+			wantDisposed: false,
+			wantPanic:    "",
+		},
+		{
+			name: "inherited 1",
+			arrange: func(t *testing.T) (context.Context, context.CancelFunc, cdp.BrowserContextID) {
+				ctx, cancel := NewContext(rootCtx1)
+				if err := Run(ctx); err != nil {
+					t.Fatal(err)
+				}
+				return ctx, cancel, rootBrowserContextID1
+			},
+			wantDisposed: false,
+			wantPanic:    "",
+		},
+		{
+			name: "inherited 2",
+			arrange: func(t *testing.T) (context.Context, context.CancelFunc, cdp.BrowserContextID) {
+				ctx1, _ := NewContext(rootCtx1)
+				if err := Run(ctx1); err != nil {
+					t.Fatal(err)
+				}
+				ctx, cancel := NewContext(ctx1)
+				if err := Run(ctx); err != nil {
+					t.Fatal(err)
+				}
+				return ctx, cancel, rootBrowserContextID1
+			},
+			wantDisposed: false,
+			wantPanic:    "",
+		},
+		{
+			name: "inherited 3",
+			arrange: func(t *testing.T) (context.Context, context.CancelFunc, cdp.BrowserContextID) {
+				ctx1, _ := NewContext(browserCtx, WithExistingBrowserContext(rootBrowserContextID1))
+				if err := Run(ctx1); err != nil {
+					t.Fatal(err)
+				}
+				ctx, cancel := NewContext(ctx1)
+				if err := Run(ctx); err != nil {
+					t.Fatal(err)
+				}
+				return ctx, cancel, rootBrowserContextID1
+			},
+			wantDisposed: false,
+			wantPanic:    "",
+		},
+		{
+			name: "break inheritance 1",
+			arrange: func(t *testing.T) (context.Context, context.CancelFunc, cdp.BrowserContextID) {
+				ctx, cancel := NewContext(rootCtx1, WithExistingBrowserContext(rootBrowserContextID2))
+				if err := Run(ctx); err != nil {
+					t.Fatal(err)
+				}
+				// The target should be added to the second browser context.
+				return ctx, cancel, rootBrowserContextID2
+			},
+			wantDisposed: false,
+			wantPanic:    "",
+		},
+		{
+			name: "break inheritance 2",
+			arrange: func(t *testing.T) (context.Context, context.CancelFunc, cdp.BrowserContextID) {
+				ctx, cancel := NewContext(rootCtx1, WithNewBrowserContext())
+				if err := Run(ctx); err != nil {
+					t.Fatal(err)
+				}
+				c := FromContext(ctx)
+				if c.BrowserContextID == rootBrowserContextID1 {
+					t.Fatal("a new BrowserContext should be created")
+				}
+				return ctx, cancel, c.BrowserContextID
+			},
+			wantDisposed: true,
+			wantPanic:    "",
+		},
+		{
+			name: "break inheritance 3",
+			arrange: func(t *testing.T) (context.Context, context.CancelFunc, cdp.BrowserContextID) {
+				ctx, cancel := NewContext(rootCtx1, WithTargetID(FromContext(rootCtx2).Target.TargetID))
+				if err := Run(ctx); err != nil {
+					t.Fatal(err)
+				}
+
+				c := FromContext(ctx)
+				if c.BrowserContextID != "" {
+					t.Fatal("when a context is used to attach to a tab, its BrowserContextID should be empty")
+				}
+
+				return ctx, cancel, rootBrowserContextID2
+			},
+			wantDisposed: false,
+			wantPanic:    "",
+		},
+		{
+			name: "WithNewBrowserContext when WithTargetID is specified",
+			arrange: func(t *testing.T) (context.Context, context.CancelFunc, cdp.BrowserContextID) {
+				ctx, _ := NewContext(rootCtx1)
+				if err := Run(ctx); err != nil {
+					t.Fatal(err)
+				}
+				ctx, cancel := NewContext(browserCtx, WithTargetID(FromContext(ctx).Target.TargetID), WithNewBrowserContext())
+				if err := Run(ctx); err != nil {
+					t.Fatal(err)
+				}
+
+				return ctx, cancel, rootBrowserContextID1
+			},
+			wantDisposed: false,
+			wantPanic:    "WithNewBrowserContext can not be used when WithTargetID is specified",
+		},
+		{
+			name: "WithExistingBrowserContext when WithTargetID is specified",
+			arrange: func(t *testing.T) (context.Context, context.CancelFunc, cdp.BrowserContextID) {
+				ctx, _ := NewContext(rootCtx1)
+				if err := Run(ctx); err != nil {
+					t.Fatal(err)
+				}
+				ctx, cancel := NewContext(browserCtx, WithTargetID(FromContext(ctx).Target.TargetID), WithExistingBrowserContext(rootBrowserContextID2))
+				if err := Run(ctx); err != nil {
+					t.Fatal(err)
+				}
+
+				return ctx, cancel, rootBrowserContextID1
+			},
+			wantDisposed: false,
+			wantPanic:    "WithExistingBrowserContext can not be used when WithTargetID is specified",
+		},
+		{
+			name: "WithNewBrowserContext before Browser is initialized",
+			arrange: func(t *testing.T) (context.Context, context.CancelFunc, cdp.BrowserContextID) {
+				ctx, cancel := NewContext(context.Background(), WithNewBrowserContext())
+				if err := Run(ctx); err != nil {
+					t.Fatal(err)
+				}
+
+				return ctx, cancel, ""
+			},
+			wantDisposed: false,
+			wantPanic:    "WithNewBrowserContext can not be used before Browser is initialized",
+		},
+		{
+			name: "WithExistingBrowserContext before Browser is initialized",
+			arrange: func(t *testing.T) (context.Context, context.CancelFunc, cdp.BrowserContextID) {
+				ctx, cancel := NewContext(context.Background(), WithExistingBrowserContext(rootBrowserContextID1))
+				if err := Run(ctx); err != nil {
+					t.Fatal(err)
+				}
+
+				return ctx, cancel, ""
+			},
+			wantDisposed: false,
+			wantPanic:    "WithExistingBrowserContext can not be used before Browser is initialized",
+		},
+		{
+			name: "remote allocator WithExistingBrowserContext ",
+			arrange: func(t *testing.T) (context.Context, context.CancelFunc, cdp.BrowserContextID) {
+				c := FromContext(browserCtx)
+				var conn *net.TCPConn
+				if chromedpConn, ok := c.Browser.conn.(*Conn); ok {
+					conn, _ = chromedpConn.conn.(*net.TCPConn)
+				}
+				if conn == nil {
+					t.Skip("skip when the remote debugging address is not available")
+				}
+				actx, _ := NewRemoteAllocator(context.Background(), "ws://"+conn.RemoteAddr().String())
+				ctx, cancel := NewContext(actx, WithExistingBrowserContext(rootBrowserContextID1))
+				if err := Run(ctx); err != nil {
+					t.Fatal(err)
+				}
+
+				return ctx, cancel, rootBrowserContextID1
+			},
+			wantDisposed: false,
+			wantPanic:    "",
+		},
+		{
+			name: "remote allocator WithNewBrowserContext",
+			arrange: func(t *testing.T) (context.Context, context.CancelFunc, cdp.BrowserContextID) {
+				c := FromContext(browserCtx)
+				var conn *net.TCPConn
+				if chromedpConn, ok := c.Browser.conn.(*Conn); ok {
+					conn, _ = chromedpConn.conn.(*net.TCPConn)
+				}
+				if conn == nil {
+					t.Skip("skip when the remote debugging address is not available")
+				}
+				actx, _ := NewRemoteAllocator(context.Background(), "ws://"+conn.RemoteAddr().String())
+				ctx, cancel := NewContext(actx, WithNewBrowserContext())
+				if err := Run(ctx); err != nil {
+					t.Fatal(err)
+				}
+
+				return ctx, cancel, FromContext(ctx).BrowserContextID
+			},
+			wantDisposed: true,
+			wantPanic:    "",
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.wantPanic != "" {
+				defer func() {
+					if got := fmt.Sprint(recover()); got != tt.wantPanic {
+						t.Errorf("want panic %q, got %q", tt.wantPanic, got)
+					}
+				}()
+			}
+			ctx, cancel, want := tt.arrange(t)
+			defer cancel()
+
+			got := getBrowserContext(t, ctx)
+
+			if got != want {
+				switch want {
+				case defaultBrowserContextID:
+					t.Errorf("want default browser context %q, got %q", want, got)
+				case rootBrowserContextID1:
+					t.Errorf("want root browser context 1 %q, got %q", want, got)
+				case rootBrowserContextID2:
+					t.Errorf("want root browser context 2 %q, got %q", want, got)
+				default:
+					t.Errorf("want browser context %q, got %q", want, got)
+				}
+			}
+
+			if want == defaultBrowserContextID {
+				// There is not way to check whether the default browser context
+				// is disposed, so stop here.
+				return
+			}
+
+			cancel()
+
+			var ids []cdp.BrowserContextID
+			if err := Run(browserCtx,
+				ActionFunc(func(ctx context.Context) error {
+					c := FromContext(ctx)
+					var err error
+					ids, err = target.GetBrowserContexts().Do(cdp.WithExecutor(ctx, c.Browser))
+					return err
+				}),
+			); err != nil {
+				t.Fatal(err)
+			}
+
+			disposed := !slices.Contains(ids, want)
+
+			if disposed != tt.wantDisposed {
+				t.Errorf("browser context disposed = %v, want %v", disposed, tt.wantDisposed)
+			}
+		})
+	}
+}
+
+func getBrowserContext(tb testing.TB, ctx context.Context) cdp.BrowserContextID {
+	var id cdp.BrowserContextID
+	if err := Run(ctx,
+		ActionFunc(func(ctx context.Context) error {
+			info, err := target.GetTargetInfo().Do(ctx)
+			id = info.BrowserContextID
+			return err
+		}),
+	); err != nil {
+		tb.Fatal(err)
+	}
+	return id
+}
 func TestLargeOutboundMessages(t *testing.T) {
 	t.Parallel()
 

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80
 	github.com/mailru/easyjson v0.7.7
 	github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde
+	golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2
 )
 
 require (
@@ -15,5 +16,5 @@ require (
 	github.com/gobwas/httphead v0.1.0 // indirect
 	github.com/gobwas/pool v0.2.1 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
-	golang.org/x/sys v0.0.0-20220928140112-f11e5e49a4ec // indirect
+	golang.org/x/sys v0.1.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde h1:x0TT0RDC7UhAVbbWWBzr41ElhJx5tXPWkIHA2HWPRuw=
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzbfBr3hhjoZnS66nKrHmduYNpc34ny7RK4z5/HM0=
+golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2 h1:Jvc7gsqn21cJHCmAWx0LiimpP18LZmUxkT5Mp7EZ1mI=
+golang.org/x/exp v0.0.0-20230224173230-c95f2b4c22f2/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/sys v0.0.0-20201207223542-d4d67f95c62d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20220928140112-f11e5e49a4ec h1:BkDtF2Ih9xZ7le9ndzTA7KJow28VbQW3odyk/8drmuI=
-golang.org/x/sys v0.0.0-20220928140112-f11e5e49a4ec/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
+golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
A `BrowserContext` is similar to an incognito profile but you can have more than one. Don't get confused by the name, it has nothing to do with the Go package "context".

Two more `chromedp.ContextOption`s are added:

- `WithNewBrowserContext`: to create a target in a new `BrowserContext`.
- `WithExistingBrowserContext`: to create a target in an existing `BrowserContext`.

If the context is created with the `WithNewBrowserContext` option, the id of the new `BrowserContext` can be retrived by:

```go
chromedp.FromContext(ctx).BrowserContextID
```

Fixes #1267 
Fixes #1237
Updates #1193
Updates #997
Updates #799