### PR TITLE
Fix leaked temp dirs when run TestConcurrentCancel

### DIFF
--- a/chromedp_test.go
+++ b/chromedp_test.go
@@ -333,12 +333,21 @@ func TestConcurrentCancel(t *testing.T) {
 		ExecPath("/do-not-run-chrome"))
 	defer cancel()
 
+	var wg sync.WaitGroup
 	// 50 is enough for 'go test -race' to easily spot issues.
 	for i := 0; i < 50; i++ {
+		wg.Add(2)
 		ctx, cancel := NewContext(allocCtx)
-		go cancel()
-		go Run(ctx)
+		go func() {
+			cancel()
+			wg.Done()
+		}()
+		go func() {
+			_ = Run(ctx)
+			wg.Done()
+		}()
 	}
+	wg.Wait()
 }
 
 func TestListenBrowser(t *testing.T) {


### PR DESCRIPTION
When executing the command (`runtime.GOMAXPROCS` >= 2):
```
go test -run ^TestConcurrentCancel$ github.com/chromedp/chromedp -count=1 -v -race
```
panic appears:
```
leaked 38 temporary dirs under /var/folders/hj/d_p08kpd495fj0zprd5m51500000gp/T/chromedp-test3640163383
```