### PR TITLE
all: go fix -fix buildtag

### DIFF
--- a/allocate_linux.go
+++ b/allocate_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package chromedp
 

--- a/allocate_other.go
+++ b/allocate_other.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package chromedp
 

--- a/device/gen.go
+++ b/device/gen.go
@@ -1,5 +1,4 @@
 //go:build ignore
-// +build ignore
 
 package main
 

--- a/kb/gen.go
+++ b/kb/gen.go
@@ -1,5 +1,4 @@
 //go:build ignore
-// +build ignore
 
 package main
 


### PR DESCRIPTION
Remove `// +build` comments from the module because it uses Go 1.18 or later.