### PR TITLE
replace "interface{}" with "any"

### DIFF
--- a/allocate.go
+++ b/allocate.go
@@ -36,7 +36,7 @@ type Allocator interface {
 // to create the allocator without the unnecessary context layer.
 func setupExecAllocator(opts ...ExecAllocatorOption) *ExecAllocator {
 	ep := &ExecAllocator{
-		initFlags:        make(map[string]interface{}),
+		initFlags:        make(map[string]any),
 		wsURLReadTimeout: 20 * time.Second,
 	}
 	for _, o := range opts {
@@ -104,7 +104,7 @@ type ExecAllocatorOption = func(*ExecAllocator)
 // machine.
 type ExecAllocator struct {
 	execPath  string
-	initFlags map[string]interface{}
+	initFlags map[string]any
 	initEnv   []string
 
 	// Chrome will sometimes fail to print the websocket, or run for a long
@@ -397,7 +397,7 @@ func findExecPath() string {
 // Flag is a generic command line option to pass a flag to Chrome. If the value
 // is a string, it will be passed as --name=value. If it's a boolean, it will be
 // passed as --name if value is true.
-func Flag(name string, value interface{}) ExecAllocatorOption {
+func Flag(name string, value any) ExecAllocatorOption {
 	return func(a *ExecAllocator) {
 		a.initFlags[name] = value
 	}

--- a/allocate_test.go
+++ b/allocate_test.go
@@ -220,7 +220,7 @@ func testRemoteAllocator(t *testing.T, modifyURL func(wsURL string) string, want
 
 	taskCtx, taskCancel := NewContext(allocCtx,
 		// This used to crash when used with RemoteAllocator.
-		WithLogf(func(format string, args ...interface{}) {}),
+		WithLogf(func(format string, args ...any) {}),
 	)
 
 	{
@@ -410,7 +410,7 @@ func TestWithBrowserOptionAlreadyAllocated(t *testing.T) {
 	// This needs to panic, as we try to set up a browser logf function
 	// after the browser has already been set up earlier.
 	_, _ = NewContext(ctx,
-		WithLogf(func(format string, args ...interface{}) {}),
+		WithLogf(func(format string, args ...any) {}),
 	)
 }
 

--- a/browser.go
+++ b/browser.go
@@ -61,9 +61,9 @@ type Browser struct {
 	cmdQueue chan *cdproto.Message
 
 	// logging funcs
-	logf func(string, ...interface{})
-	errf func(string, ...interface{})
-	dbgf func(string, ...interface{})
+	logf func(string, ...any)
+	errf func(string, ...any)
+	dbgf func(string, ...any)
 
 	// The optional fields below are helpful for some tests.
 
@@ -98,7 +98,7 @@ func NewBrowser(ctx context.Context, urlstr string, opts ...BrowserOption) (*Bro
 	}
 	// ensure errf is set
 	if b.errf == nil {
-		b.errf = func(s string, v ...interface{}) { b.logf("ERROR: "+s, v...) }
+		b.errf = func(s string, v ...any) { b.logf("ERROR: "+s, v...) }
 	}
 
 	dialCtx := ctx
@@ -178,7 +178,7 @@ func (b *Browser) execute(ctx context.Context, method string, params easyjson.Ma
 	id := atomic.AddInt64(&b.next, 1)
 	lctx, cancel := context.WithCancel(ctx)
 	ch := make(chan *cdproto.Message, 1)
-	fn := func(ev interface{}) {
+	fn := func(ev any) {
 		if msg, ok := ev.(*cdproto.Message); ok && msg.ID == id {
 			select {
 			case <-ctx.Done():
@@ -330,25 +330,25 @@ func (b *Browser) run(ctx context.Context) {
 type BrowserOption = func(*Browser)
 
 // WithBrowserLogf is a browser option to specify a func to receive general logging.
-func WithBrowserLogf(f func(string, ...interface{})) BrowserOption {
+func WithBrowserLogf(f func(string, ...any)) BrowserOption {
 	return func(b *Browser) { b.logf = f }
 }
 
 // WithBrowserErrorf is a browser option to specify a func to receive error logging.
-func WithBrowserErrorf(f func(string, ...interface{})) BrowserOption {
+func WithBrowserErrorf(f func(string, ...any)) BrowserOption {
 	return func(b *Browser) { b.errf = f }
 }
 
 // WithBrowserDebugf is a browser option to specify a func to log actual
 // websocket messages.
-func WithBrowserDebugf(f func(string, ...interface{})) BrowserOption {
+func WithBrowserDebugf(f func(string, ...any)) BrowserOption {
 	return func(b *Browser) { b.dbgf = f }
 }
 
 // WithConsolef is a browser option to specify a func to receive chrome log events.
 //
 // Note: NOT YET IMPLEMENTED.
-func WithConsolef(f func(string, ...interface{})) BrowserOption {
+func WithConsolef(f func(string, ...any)) BrowserOption {
 	return func(b *Browser) {}
 }
 

--- a/call.go
+++ b/call.go
@@ -21,14 +21,14 @@ type CallAction Action
 // - WithArguments: pass the arguments with args instead.
 //
 // Note: any exception encountered will be returned as an error.
-func CallFunctionOn(functionDeclaration string, res interface{}, opt CallOption, args ...interface{}) CallAction {
+func CallFunctionOn(functionDeclaration string, res any, opt CallOption, args ...any) CallAction {
 	return ActionFunc(func(ctx context.Context) error {
 		_, err := callFunctionOn(ctx, functionDeclaration, res, opt, args...)
 		return err
 	})
 }
 
-func callFunctionOn(ctx context.Context, functionDeclaration string, res interface{}, opt CallOption, args ...interface{}) (*runtime.RemoteObject, error) {
+func callFunctionOn(ctx context.Context, functionDeclaration string, res any, opt CallOption, args ...any) (*runtime.RemoteObject, error) {
 	// set up parameters
 	p := runtime.CallFunctionOn(functionDeclaration).
 		WithSilent(true)
@@ -83,7 +83,7 @@ type errAppender struct {
 // append method calls the json.Marshal method to marshal the value and appends it to the slice.
 // It records the first error for future reference.
 // As soon as an error occurs, the append method becomes a no-op but the error value is saved.
-func (ea *errAppender) append(v interface{}) {
+func (ea *errAppender) append(v any) {
 	if ea.err != nil {
 		return
 	}

--- a/chromedp.go
+++ b/chromedp.go
@@ -376,7 +376,7 @@ func (c *Context) newTarget(ctx context.Context) error {
 	// This is like WaitNewTarget, but for the entire browser.
 	ch := make(chan target.ID, 1)
 	lctx, cancel := context.WithCancel(ctx)
-	ListenBrowser(lctx, func(ev interface{}) {
+	ListenBrowser(lctx, func(ev any) {
 		var info *target.Info
 		switch ev := ev.(type) {
 		case *target.EventTargetCreated:
@@ -510,17 +510,17 @@ func WithExistingBrowserContext(id cdp.BrowserContextID) ContextOption {
 }
 
 // WithLogf is a shortcut for WithBrowserOption(WithBrowserLogf(f)).
-func WithLogf(f func(string, ...interface{})) ContextOption {
+func WithLogf(f func(string, ...any)) ContextOption {
 	return WithBrowserOption(WithBrowserLogf(f))
 }
 
 // WithErrorf is a shortcut for WithBrowserOption(WithBrowserErrorf(f)).
-func WithErrorf(f func(string, ...interface{})) ContextOption {
+func WithErrorf(f func(string, ...any)) ContextOption {
 	return WithBrowserOption(WithBrowserErrorf(f))
 }
 
 // WithDebugf is a shortcut for WithBrowserOption(WithBrowserDebugf(f)).
-func WithDebugf(f func(string, ...interface{})) ContextOption {
+func WithDebugf(f func(string, ...any)) ContextOption {
 	return WithBrowserOption(WithBrowserDebugf(f))
 }
 
@@ -578,7 +578,7 @@ func responseAction(resp **network.Response, actions ...Action) Action {
 
 		lctx, lcancel := context.WithCancel(ctx)
 		defer lcancel()
-		handleEvent := func(ev interface{}) {
+		handleEvent := func(ev any) {
 			switch ev := ev.(type) {
 			case *network.EventRequestWillBeSent:
 				if ev.LoaderID == loaderID && ev.Type == network.ResourceTypeDocument {
@@ -613,7 +613,7 @@ func responseAction(resp **network.Response, actions ...Action) Action {
 		}
 		// earlyEvents is a buffered list of events which happened
 		// before we knew what loaderID to look for.
-		var earlyEvents []interface{}
+		var earlyEvents []any
 
 		// Obtain frameID from the target.
 		c := FromContext(ctx)
@@ -621,7 +621,7 @@ func responseAction(resp **network.Response, actions ...Action) Action {
 		frameID = c.Target.cur
 		c.Target.frameMu.Unlock()
 
-		ListenTarget(lctx, func(ev interface{}) {
+		ListenTarget(lctx, func(ev any) {
 			if loaderID != "" {
 				handleEvent(ev)
 				return
@@ -771,7 +771,7 @@ func retryWithSleep(ctx context.Context, d time.Duration, f func(ctx context.Con
 
 type cancelableListener struct {
 	ctx context.Context
-	fn  func(ev interface{})
+	fn  func(ev any)
 }
 
 // ListenBrowser adds a function which will be called whenever a browser event
@@ -783,7 +783,7 @@ type cancelableListener struct {
 // function should avoid blocking at all costs. For example, any Actions must be
 // run via a separate goroutine (otherwise, it could result in a deadlock if the
 // action sends CDP messages).
-func ListenBrowser(ctx context.Context, fn func(ev interface{})) {
+func ListenBrowser(ctx context.Context, fn func(ev any)) {
 	c := FromContext(ctx)
 	if c == nil {
 		panic(ErrInvalidContext)
@@ -806,7 +806,7 @@ func ListenBrowser(ctx context.Context, fn func(ev interface{})) {
 // function should avoid blocking at all costs. For example, any Actions must be
 // run via a separate goroutine (otherwise, it could result in a deadlock if the
 // action sends CDP messages).
-func ListenTarget(ctx context.Context, fn func(ev interface{})) {
+func ListenTarget(ctx context.Context, fn func(ev any)) {
 	c := FromContext(ctx)
 	if c == nil {
 		panic(ErrInvalidContext)
@@ -827,7 +827,7 @@ func ListenTarget(ctx context.Context, fn func(ev interface{})) {
 func WaitNewTarget(ctx context.Context, fn func(*target.Info) bool) <-chan target.ID {
 	ch := make(chan target.ID, 1)
 	lctx, cancel := context.WithCancel(ctx)
-	ListenTarget(lctx, func(ev interface{}) {
+	ListenTarget(lctx, func(ev any) {
 		var info *target.Info
 		switch ev := ev.(type) {
 		case *target.EventTargetCreated:

--- a/chromedp_test.go
+++ b/chromedp_test.go
@@ -138,7 +138,7 @@ func testAllocateSeparate(tb testing.TB) (context.Context, context.CancelFunc) {
 	if err := Run(ctx); err != nil {
 		tb.Fatal(err)
 	}
-	ListenBrowser(ctx, func(ev interface{}) {
+	ListenBrowser(ctx, func(ev any) {
 		switch ev := ev.(type) {
 		case *runtime.EventExceptionThrown:
 			tb.Errorf("%+v\n", ev.ExceptionDetails)
@@ -360,7 +360,7 @@ func TestListenBrowser(t *testing.T) {
 	// Check that many ListenBrowser callbacks work, including adding
 	// callbacks after the browser has been allocated.
 	var totalCount int32
-	ListenBrowser(ctx, func(ev interface{}) {
+	ListenBrowser(ctx, func(ev any) {
 		// using sync/atomic, as the browser is shared.
 		atomic.AddInt32(&totalCount, 1)
 	})
@@ -368,7 +368,7 @@ func TestListenBrowser(t *testing.T) {
 		t.Fatal(err)
 	}
 	seenSessions := make(map[target.SessionID]bool)
-	ListenBrowser(ctx, func(ev interface{}) {
+	ListenBrowser(ctx, func(ev any) {
 		if ev, ok := ev.(*target.EventAttachedToTarget); ok {
 			seenSessions[ev.SessionID] = true
 		}
@@ -397,7 +397,7 @@ func TestListenTarget(t *testing.T) {
 	// Check that many listen callbacks work, including adding callbacks
 	// after the target has been attached to.
 	var navigatedCount, updatedCount int
-	ListenTarget(ctx, func(ev interface{}) {
+	ListenTarget(ctx, func(ev any) {
 		if _, ok := ev.(*page.EventFrameNavigated); ok {
 			navigatedCount++
 		}
@@ -405,7 +405,7 @@ func TestListenTarget(t *testing.T) {
 	if err := Run(ctx); err != nil {
 		t.Fatal(err)
 	}
-	ListenTarget(ctx, func(ev interface{}) {
+	ListenTarget(ctx, func(ev any) {
 		if _, ok := ev.(*dom.EventDocumentUpdated); ok {
 			updatedCount++
 		}
@@ -435,7 +435,7 @@ func TestLargeEventCount(t *testing.T) {
 	// make the test fail somewhat reliably on old chromedp versions,
 	// without making the test too slow.
 	first := true
-	ListenTarget(ctx, func(ev interface{}) {
+	ListenTarget(ctx, func(ev any) {
 		if _, ok := ev.(*runtime.EventConsoleAPICalled); ok && first {
 			time.Sleep(50 * time.Millisecond)
 			first = false
@@ -535,13 +535,13 @@ func TestListenCancel(t *testing.T) {
 	var browserCount, targetCount int
 
 	ctx1, cancel1 := context.WithCancel(ctx)
-	ListenBrowser(ctx1, func(ev interface{}) {
+	ListenBrowser(ctx1, func(ev any) {
 		browserCount++
 		cancel1()
 	})
 
 	ctx2, cancel2 := context.WithCancel(ctx)
-	ListenTarget(ctx2, func(ev interface{}) {
+	ListenTarget(ctx2, func(ev any) {
 		targetCount++
 		cancel2()
 	})
@@ -562,7 +562,7 @@ func TestLogOptions(t *testing.T) {
 
 	var bufMu sync.Mutex
 	var buf bytes.Buffer
-	fn := func(format string, a ...interface{}) {
+	fn := func(format string, a ...any) {
 		bufMu.Lock()
 		fmt.Fprintf(&buf, format, a...)
 		fmt.Fprintln(&buf)
@@ -1000,7 +1000,7 @@ func TestDownloadIntoDir(t *testing.T) {
 	defer s.Close()
 
 	done := make(chan string, 1)
-	ListenTarget(ctx, func(v interface{}) {
+	ListenTarget(ctx, func(v any) {
 		if ev, ok := v.(*browser.EventDownloadProgress); ok {
 			if ev.State == browser.DownloadProgressStateCompleted {
 				done <- ev.GUID
@@ -1113,7 +1113,7 @@ func TestAttachingToWorkers(t *testing.T) {
 
 			ch := make(chan target.ID, 1)
 
-			ListenTarget(ctx, func(ev interface{}) {
+			ListenTarget(ctx, func(ev any) {
 				if ev, ok := ev.(*target.EventAttachedToTarget); ok {
 					if !strings.Contains(ev.TargetInfo.Type, "worker") {
 						return

--- a/conn.go
+++ b/conn.go
@@ -37,7 +37,7 @@ type Conn struct {
 	decoder jlexer.Lexer
 	encoder jwriter.Writer
 
-	dbgf func(string, ...interface{})
+	dbgf func(string, ...any)
 }
 
 // DialContext dials the specified websocket URL using gobwas/ws.
@@ -141,7 +141,7 @@ func (c *Conn) Write(_ context.Context, msg *cdproto.Message) error {
 type DialOption = func(*Conn)
 
 // WithConnDebugf is a dial option to set a protocol logger.
-func WithConnDebugf(f func(string, ...interface{})) DialOption {
+func WithConnDebugf(f func(string, ...any)) DialOption {
 	return func(c *Conn) {
 		c.dbgf = f
 	}

--- a/eval.go
+++ b/eval.go
@@ -32,7 +32,7 @@ type EvaluateAction Action
 // and the value that res points to can not be nil (only the value of a chan,
 // func, interface, map, pointer, or slice can be nil), it returns [ErrJSUndefined]
 // or [ErrJSNull] respectively.
-func Evaluate(expression string, res interface{}, opts ...EvaluateOption) EvaluateAction {
+func Evaluate(expression string, res any, opts ...EvaluateOption) EvaluateAction {
 	return ActionFunc(func(ctx context.Context) error {
 		// set up parameters
 		p := runtime.Evaluate(expression)
@@ -60,7 +60,7 @@ func Evaluate(expression string, res interface{}, opts ...EvaluateOption) Evalua
 	})
 }
 
-func parseRemoteObject(v *runtime.RemoteObject, res interface{}) (err error) {
+func parseRemoteObject(v *runtime.RemoteObject, res any) (err error) {
 	if res == nil {
 		return
 	}
@@ -108,7 +108,7 @@ func parseRemoteObject(v *runtime.RemoteObject, res interface{}) (err error) {
 // See [Evaluate] for more information on how script expressions are evaluated.
 //
 // Note: this should not be used with untrusted JavaScript.
-func EvaluateAsDevTools(expression string, res interface{}, opts ...EvaluateOption) EvaluateAction {
+func EvaluateAsDevTools(expression string, res any, opts ...EvaluateOption) EvaluateAction {
 	return Evaluate(expression, res, append(opts, EvalObjectGroup("console"), EvalWithCommandLineAPI)...)
 }
 

--- a/event_test.go
+++ b/event_test.go
@@ -119,7 +119,7 @@ func TestCloseDialog(t *testing.T) {
 			ctx, cancel := testAllocate(t, "")
 			defer cancel()
 
-			ListenTarget(ctx, func(ev interface{}) {
+			ListenTarget(ctx, func(ev any) {
 				switch e := ev.(type) {
 				case *page.EventJavascriptDialogOpening:
 					if e.Type != test.dialogType {

--- a/example_test.go
+++ b/example_test.go
@@ -243,7 +243,7 @@ func ExampleListenTarget_consoleLog() {
 	defer ts.Close()
 
 	gotException := make(chan bool, 1)
-	chromedp.ListenTarget(ctx, func(ev interface{}) {
+	chromedp.ListenTarget(ctx, func(ev any) {
 		switch ev := ev.(type) {
 		case *runtime.EventConsoleAPICalled:
 			fmt.Printf("* console.%s call:\n", ev.Type)
@@ -325,7 +325,7 @@ func ExampleListenTarget_acceptAlert() {
 	`))
 	defer ts.Close()
 
-	chromedp.ListenTarget(ctx, func(ev interface{}) {
+	chromedp.ListenTarget(ctx, func(ev any) {
 		if ev, ok := ev.(*page.EventJavascriptDialogOpening); ok {
 			fmt.Println("closing alert:", ev.Message)
 			go func() {

--- a/nav_test.go
+++ b/nav_test.go
@@ -329,7 +329,7 @@ func TestNavigateWhileLoading(t *testing.T) {
 			var wg sync.WaitGroup
 			wg.Add(1)
 			lctx, cancel := context.WithCancel(ctx)
-			ListenTarget(lctx, func(ev interface{}) {
+			ListenTarget(lctx, func(ev any) {
 				if ev, ok := ev.(*page.EventLifecycleEvent); ok {
 					if ev.Name == "init" {
 						cancel()

--- a/poll.go
+++ b/poll.go
@@ -23,8 +23,8 @@ type pollTask struct {
 	polling   string        // the polling mode, defaults to "raf" (triggered by requestAnimationFrame)
 	interval  time.Duration // the interval when the poll is triggered by a timer
 	timeout   time.Duration // the poll timeout, defaults to 30 seconds
-	args      []interface{}
-	res       interface{}
+	args      []any
+	res       any
 }
 
 // Do executes the poll task in the browser,
@@ -56,7 +56,7 @@ func (p *pollTask) Do(ctx context.Context) error {
 		t.frameMu.RUnlock()
 	}
 
-	args := make([]interface{}, 0, len(p.args)+3)
+	args := make([]any, 0, len(p.args)+3)
 	args = append(args, p.predicate)
 	if p.interval > 0 {
 		args = append(args, p.interval.Milliseconds())
@@ -109,7 +109,7 @@ func (p *pollTask) Do(ctx context.Context) error {
 // See [PollFunction].
 //
 // [page.waitForFunction]: https://github.com/puppeteer/puppeteer/blob/v8.0.0/docs/api.md#pagewaitforfunctionpagefunction-options-args
-func Poll(expression string, res interface{}, opts ...PollOption) PollAction {
+func Poll(expression string, res any, opts ...PollOption) PollAction {
 	predicate := fmt.Sprintf(`return (%s);`, expression)
 	return poll(predicate, res, opts...)
 }
@@ -118,13 +118,13 @@ func Poll(expression string, res interface{}, opts ...PollOption) PollAction {
 // It builds the predicate from a JavaScript function.
 //
 // See [Poll] for details on building poll tasks.
-func PollFunction(pageFunction string, res interface{}, opts ...PollOption) PollAction {
+func PollFunction(pageFunction string, res any, opts ...PollOption) PollAction {
 	predicate := fmt.Sprintf(`return (%s)(...args);`, pageFunction)
 
 	return poll(predicate, res, opts...)
 }
 
-func poll(predicate string, res interface{}, opts ...PollOption) PollAction {
+func poll(predicate string, res any, opts ...PollOption) PollAction {
 	p := &pollTask{
 		predicate: predicate,
 		polling:   "raf",
@@ -175,7 +175,7 @@ func WithPollingInFrame(frame *cdp.Node) PollOption {
 }
 
 // WithPollingArgs provides extra arguments to pass to the predicate.
-func WithPollingArgs(args ...interface{}) PollOption {
+func WithPollingArgs(args ...any) PollOption {
 	return func(w *pollTask) {
 		w.args = args
 	}

--- a/query.go
+++ b/query.go
@@ -26,7 +26,7 @@ type QueryAction Action
 // See [Query] for information on building an element selector and relevant
 // options.
 type Selector struct {
-	sel           interface{}
+	sel           any
 	fromNode      *cdp.Node
 	retryInterval time.Duration
 	exp           int
@@ -127,7 +127,7 @@ type Selector struct {
 //
 // The [NodeNotPresent] option causes the query to wait until there are no
 // element nodes matching the selector.
-func Query(sel interface{}, opts ...QueryOption) QueryAction {
+func Query(sel any, opts ...QueryOption) QueryAction {
 	s := &Selector{
 		sel:           sel,
 		exp:           1,
@@ -259,7 +259,7 @@ func (s *Selector) waitReady(check func(context.Context, runtime.ExecutionContex
 // QueryAfter is an element query action that queries the browser for selector
 // sel. Waits until the visibility conditions of the query have been met, after
 // which executes f.
-func QueryAfter(sel interface{}, f func(context.Context, runtime.ExecutionContextID, ...*cdp.Node) error, opts ...QueryOption) QueryAction {
+func QueryAfter(sel any, f func(context.Context, runtime.ExecutionContextID, ...*cdp.Node) error, opts ...QueryOption) QueryAction {
 	return Query(sel, append(opts, After(f))...)
 }
 
@@ -417,7 +417,7 @@ func NodeReady(s *Selector) {
 	WaitFunc(s.waitReady(nil))(s)
 }
 
-func callFunctionOnNode(ctx context.Context, node *cdp.Node, function string, res interface{}, args ...interface{}) error {
+func callFunctionOnNode(ctx context.Context, node *cdp.Node, function string, res any, args ...any) error {
 	r, err := dom.ResolveNode().WithNodeID(node.NodeID).Do(ctx)
 	if err != nil {
 		return err
@@ -576,43 +576,43 @@ func After(f func(context.Context, runtime.ExecutionContextID, ...*cdp.Node) err
 
 // WaitReady is an element query action that waits until the element matching
 // the selector is ready (i.e., has been "loaded").
-func WaitReady(sel interface{}, opts ...QueryOption) QueryAction {
+func WaitReady(sel any, opts ...QueryOption) QueryAction {
 	return Query(sel, opts...)
 }
 
 // WaitVisible is an element query action that waits until the element matching
 // the selector is visible.
-func WaitVisible(sel interface{}, opts ...QueryOption) QueryAction {
+func WaitVisible(sel any, opts ...QueryOption) QueryAction {
 	return Query(sel, append(opts, NodeVisible)...)
 }
 
 // WaitNotVisible is an element query action that waits until the element
 // matching the selector is not visible.
-func WaitNotVisible(sel interface{}, opts ...QueryOption) QueryAction {
+func WaitNotVisible(sel any, opts ...QueryOption) QueryAction {
 	return Query(sel, append(opts, NodeNotVisible)...)
 }
 
 // WaitEnabled is an element query action that waits until the element matching
 // the selector is enabled (i.e., does not have attribute 'disabled').
-func WaitEnabled(sel interface{}, opts ...QueryOption) QueryAction {
+func WaitEnabled(sel any, opts ...QueryOption) QueryAction {
 	return Query(sel, append(opts, NodeEnabled)...)
 }
 
 // WaitSelected is an element query action that waits until the element
 // matching the selector is selected (i.e., has attribute 'selected').
-func WaitSelected(sel interface{}, opts ...QueryOption) QueryAction {
+func WaitSelected(sel any, opts ...QueryOption) QueryAction {
 	return Query(sel, append(opts, NodeSelected)...)
 }
 
 // WaitNotPresent is an element query action that waits until no elements are
 // present matching the selector.
-func WaitNotPresent(sel interface{}, opts ...QueryOption) QueryAction {
+func WaitNotPresent(sel any, opts ...QueryOption) QueryAction {
 	return Query(sel, append(opts, NodeNotPresent)...)
 }
 
 // Nodes is an element query action that retrieves the document element nodes
 // matching the selector.
-func Nodes(sel interface{}, nodes *[]*cdp.Node, opts ...QueryOption) QueryAction {
+func Nodes(sel any, nodes *[]*cdp.Node, opts ...QueryOption) QueryAction {
 	if nodes == nil {
 		panic("nodes cannot be nil")
 	}
@@ -625,7 +625,7 @@ func Nodes(sel interface{}, nodes *[]*cdp.Node, opts ...QueryOption) QueryAction
 
 // NodeIDs is an element query action that retrieves the element node IDs matching the
 // selector.
-func NodeIDs(sel interface{}, ids *[]cdp.NodeID, opts ...QueryOption) QueryAction {
+func NodeIDs(sel any, ids *[]cdp.NodeID, opts ...QueryOption) QueryAction {
 	if ids == nil {
 		panic("nodes cannot be nil")
 	}
@@ -644,7 +644,7 @@ func NodeIDs(sel interface{}, ids *[]cdp.NodeID, opts ...QueryOption) QueryActio
 
 // Focus is an element query action that focuses the first element node matching the
 // selector.
-func Focus(sel interface{}, opts ...QueryOption) QueryAction {
+func Focus(sel any, opts ...QueryOption) QueryAction {
 	return QueryAfter(sel, func(ctx context.Context, execCtx runtime.ExecutionContextID, nodes ...*cdp.Node) error {
 		if len(nodes) < 1 {
 			return fmt.Errorf("selector %q did not return any nodes", sel)
@@ -656,7 +656,7 @@ func Focus(sel interface{}, opts ...QueryOption) QueryAction {
 
 // Blur is an element query action that unfocuses (blurs) the first element node
 // matching the selector.
-func Blur(sel interface{}, opts ...QueryOption) QueryAction {
+func Blur(sel any, opts ...QueryOption) QueryAction {
 	return QueryAfter(sel, func(ctx context.Context, execCtx runtime.ExecutionContextID, nodes ...*cdp.Node) error {
 		if len(nodes) < 1 {
 			return fmt.Errorf("selector %q did not return any nodes", sel)
@@ -678,7 +678,7 @@ func Blur(sel interface{}, opts ...QueryOption) QueryAction {
 
 // Dimensions is an element query action that retrieves the box model dimensions for the
 // first element node matching the selector.
-func Dimensions(sel interface{}, model **dom.BoxModel, opts ...QueryOption) QueryAction {
+func Dimensions(sel any, model **dom.BoxModel, opts ...QueryOption) QueryAction {
 	if model == nil {
 		panic("model cannot be nil")
 	}
@@ -694,7 +694,7 @@ func Dimensions(sel interface{}, model **dom.BoxModel, opts ...QueryOption) Quer
 
 // Text is an element query action that retrieves the visible text of the first element
 // node matching the selector.
-func Text(sel interface{}, text *string, opts ...QueryOption) QueryAction {
+func Text(sel any, text *string, opts ...QueryOption) QueryAction {
 	if text == nil {
 		panic("text cannot be nil")
 	}
@@ -710,7 +710,7 @@ func Text(sel interface{}, text *string, opts ...QueryOption) QueryAction {
 
 // TextContent is an element query action that retrieves the text content of the first element
 // node matching the selector.
-func TextContent(sel interface{}, text *string, opts ...QueryOption) QueryAction {
+func TextContent(sel any, text *string, opts ...QueryOption) QueryAction {
 	if text == nil {
 		panic("text cannot be nil")
 	}
@@ -726,7 +726,7 @@ func TextContent(sel interface{}, text *string, opts ...QueryOption) QueryAction
 
 // Clear is an element query action that clears the values of any input/textarea element
 // nodes matching the selector.
-func Clear(sel interface{}, opts ...QueryOption) QueryAction {
+func Clear(sel any, opts ...QueryOption) QueryAction {
 	return QueryAfter(sel, func(ctx context.Context, execCtx runtime.ExecutionContextID, nodes ...*cdp.Node) error {
 		if len(nodes) < 1 {
 			return fmt.Errorf("selector %q did not return any nodes", sel)
@@ -787,7 +787,7 @@ func Clear(sel interface{}, opts ...QueryOption) QueryAction {
 //
 // Useful for retrieving an element's JavaScript value, namely form, input,
 // textarea, select, or any other element with a '.value' field.
-func Value(sel interface{}, value *string, opts ...QueryOption) QueryAction {
+func Value(sel any, value *string, opts ...QueryOption) QueryAction {
 	if value == nil {
 		panic("value cannot be nil")
 	}
@@ -800,13 +800,13 @@ func Value(sel interface{}, value *string, opts ...QueryOption) QueryAction {
 //
 // Useful for setting an element's JavaScript value, namely form, input,
 // textarea, select, or other element with a '.value' field.
-func SetValue(sel interface{}, value string, opts ...QueryOption) QueryAction {
+func SetValue(sel any, value string, opts ...QueryOption) QueryAction {
 	return SetJavascriptAttribute(sel, "value", value, opts...)
 }
 
 // Attributes is an element query action that retrieves the element attributes for the
 // first element node matching the selector.
-func Attributes(sel interface{}, attributes *map[string]string, opts ...QueryOption) QueryAction {
+func Attributes(sel any, attributes *map[string]string, opts ...QueryOption) QueryAction {
 	if attributes == nil {
 		panic("attributes cannot be nil")
 	}
@@ -835,7 +835,7 @@ func Attributes(sel interface{}, attributes *map[string]string, opts ...QueryOpt
 // all element nodes matching the selector.
 //
 // Note: this should be used with the ByQueryAll query option.
-func AttributesAll(sel interface{}, attributes *[]map[string]string, opts ...QueryOption) QueryAction {
+func AttributesAll(sel any, attributes *[]map[string]string, opts ...QueryOption) QueryAction {
 	if attributes == nil {
 		panic("attributes cannot be nil")
 	}
@@ -861,7 +861,7 @@ func AttributesAll(sel interface{}, attributes *[]map[string]string, opts ...Que
 
 // SetAttributes is an element query action that sets the element attributes for the
 // first element node matching the selector.
-func SetAttributes(sel interface{}, attributes map[string]string, opts ...QueryOption) QueryAction {
+func SetAttributes(sel any, attributes map[string]string, opts ...QueryOption) QueryAction {
 	return QueryAfter(sel, func(ctx context.Context, execCtx runtime.ExecutionContextID, nodes ...*cdp.Node) error {
 		if len(nodes) < 1 {
 			return errors.New("expected at least one element")
@@ -879,7 +879,7 @@ func SetAttributes(sel interface{}, attributes map[string]string, opts ...QueryO
 
 // AttributeValue is an element query action that retrieves the element attribute value
 // for the first element node matching the selector.
-func AttributeValue(sel interface{}, name string, value *string, ok *bool, opts ...QueryOption) QueryAction {
+func AttributeValue(sel any, name string, value *string, ok *bool, opts ...QueryOption) QueryAction {
 	if value == nil {
 		panic("value cannot be nil")
 	}
@@ -913,7 +913,7 @@ func AttributeValue(sel interface{}, name string, value *string, ok *bool, opts 
 
 // SetAttributeValue is an element query action that sets the element attribute with
 // name to value for the first element node matching the selector.
-func SetAttributeValue(sel interface{}, name, value string, opts ...QueryOption) QueryAction {
+func SetAttributeValue(sel any, name, value string, opts ...QueryOption) QueryAction {
 	return QueryAfter(sel, func(ctx context.Context, execCtx runtime.ExecutionContextID, nodes ...*cdp.Node) error {
 		if len(nodes) < 1 {
 			return fmt.Errorf("selector %q did not return any nodes", sel)
@@ -925,7 +925,7 @@ func SetAttributeValue(sel interface{}, name, value string, opts ...QueryOption)
 
 // RemoveAttribute is an element query action that removes the element attribute with
 // name from the first element node matching the selector.
-func RemoveAttribute(sel interface{}, name string, opts ...QueryOption) QueryAction {
+func RemoveAttribute(sel any, name string, opts ...QueryOption) QueryAction {
 	return QueryAfter(sel, func(ctx context.Context, execCtx runtime.ExecutionContextID, nodes ...*cdp.Node) error {
 		if len(nodes) < 1 {
 			return fmt.Errorf("selector %q did not return any nodes", sel)
@@ -937,7 +937,7 @@ func RemoveAttribute(sel interface{}, name string, opts ...QueryOption) QueryAct
 
 // JavascriptAttribute is an element query action that retrieves the JavaScript
 // attribute for the first element node matching the selector.
-func JavascriptAttribute(sel interface{}, name string, res interface{}, opts ...QueryOption) QueryAction {
+func JavascriptAttribute(sel any, name string, res any, opts ...QueryOption) QueryAction {
 	if res == nil {
 		panic("res cannot be nil")
 	}
@@ -956,7 +956,7 @@ func JavascriptAttribute(sel interface{}, name string, res interface{}, opts ...
 
 // SetJavascriptAttribute is an element query action that sets the JavaScript attribute
 // for the first element node matching the selector.
-func SetJavascriptAttribute(sel interface{}, name, value string, opts ...QueryOption) QueryAction {
+func SetJavascriptAttribute(sel any, name, value string, opts ...QueryOption) QueryAction {
 	return QueryAfter(sel, func(ctx context.Context, execCtx runtime.ExecutionContextID, nodes ...*cdp.Node) error {
 		if len(nodes) < 1 {
 			return fmt.Errorf("selector %q did not return any nodes", sel)
@@ -977,7 +977,7 @@ func SetJavascriptAttribute(sel interface{}, name, value string, opts ...QueryOp
 
 // OuterHTML is an element query action that retrieves the outer html of the first
 // element node matching the selector.
-func OuterHTML(sel interface{}, html *string, opts ...QueryOption) QueryAction {
+func OuterHTML(sel any, html *string, opts ...QueryOption) QueryAction {
 	if html == nil {
 		panic("html cannot be nil")
 	}
@@ -986,7 +986,7 @@ func OuterHTML(sel interface{}, html *string, opts ...QueryOption) QueryAction {
 
 // InnerHTML is an element query action that retrieves the inner html of the first
 // element node matching the selector.
-func InnerHTML(sel interface{}, html *string, opts ...QueryOption) QueryAction {
+func InnerHTML(sel any, html *string, opts ...QueryOption) QueryAction {
 	if html == nil {
 		panic("html cannot be nil")
 	}
@@ -995,7 +995,7 @@ func InnerHTML(sel interface{}, html *string, opts ...QueryOption) QueryAction {
 
 // Click is an element query action that sends a mouse click event to the first element
 // node matching the selector.
-func Click(sel interface{}, opts ...QueryOption) QueryAction {
+func Click(sel any, opts ...QueryOption) QueryAction {
 	return QueryAfter(sel, func(ctx context.Context, execCtx runtime.ExecutionContextID, nodes ...*cdp.Node) error {
 		if len(nodes) < 1 {
 			return fmt.Errorf("selector %q did not return any nodes", sel)
@@ -1007,7 +1007,7 @@ func Click(sel interface{}, opts ...QueryOption) QueryAction {
 
 // DoubleClick is an element query action that sends a mouse double click event to the
 // first element node matching the selector.
-func DoubleClick(sel interface{}, opts ...QueryOption) QueryAction {
+func DoubleClick(sel any, opts ...QueryOption) QueryAction {
 	return QueryAfter(sel, func(ctx context.Context, execCtx runtime.ExecutionContextID, nodes ...*cdp.Node) error {
 		if len(nodes) < 1 {
 			return fmt.Errorf("selector %q did not return any nodes", sel)
@@ -1027,7 +1027,7 @@ func DoubleClick(sel interface{}, opts ...QueryOption) QueryAction {
 // dom.SetFileInputFiles is used to set the upload path of the input node to v.
 //
 // [keys]: https://github.com/chromedp/examples/tree/master/keys
-func SendKeys(sel interface{}, v string, opts ...QueryOption) QueryAction {
+func SendKeys(sel any, v string, opts ...QueryOption) QueryAction {
 	return QueryAfter(sel, func(ctx context.Context, execCtx runtime.ExecutionContextID, nodes ...*cdp.Node) error {
 		if len(nodes) < 1 {
 			return fmt.Errorf("selector %q did not return any nodes", sel)
@@ -1056,7 +1056,7 @@ func SendKeys(sel interface{}, v string, opts ...QueryOption) QueryAction {
 
 // SetUploadFiles is an element query action that sets the files to upload (i.e., for a
 // input[type="file"] node) for the first element node matching the selector.
-func SetUploadFiles(sel interface{}, files []string, opts ...QueryOption) QueryAction {
+func SetUploadFiles(sel any, files []string, opts ...QueryOption) QueryAction {
 	return QueryAfter(sel, func(ctx context.Context, execCtx runtime.ExecutionContextID, nodes ...*cdp.Node) error {
 		if len(nodes) < 1 {
 			return fmt.Errorf("selector %q did not return any nodes", sel)
@@ -1068,7 +1068,7 @@ func SetUploadFiles(sel interface{}, files []string, opts ...QueryOption) QueryA
 
 // Submit is an element query action that submits the parent form of the first element
 // node matching the selector.
-func Submit(sel interface{}, opts ...QueryOption) QueryAction {
+func Submit(sel any, opts ...QueryOption) QueryAction {
 	return QueryAfter(sel, func(ctx context.Context, execCtx runtime.ExecutionContextID, nodes ...*cdp.Node) error {
 		if len(nodes) < 1 {
 			return fmt.Errorf("selector %q did not return any nodes", sel)
@@ -1090,7 +1090,7 @@ func Submit(sel interface{}, opts ...QueryOption) QueryAction {
 
 // Reset is an element query action that resets the parent form of the first element
 // node matching the selector.
-func Reset(sel interface{}, opts ...QueryOption) QueryAction {
+func Reset(sel any, opts ...QueryOption) QueryAction {
 	return QueryAfter(sel, func(ctx context.Context, execCtx runtime.ExecutionContextID, nodes ...*cdp.Node) error {
 		if len(nodes) < 1 {
 			return fmt.Errorf("selector %q did not return any nodes", sel)
@@ -1112,7 +1112,7 @@ func Reset(sel interface{}, opts ...QueryOption) QueryAction {
 
 // ComputedStyle is an element query action that retrieves the computed style of the
 // first element node matching the selector.
-func ComputedStyle(sel interface{}, style *[]*css.ComputedStyleProperty, opts ...QueryOption) QueryAction {
+func ComputedStyle(sel any, style *[]*css.ComputedStyleProperty, opts ...QueryOption) QueryAction {
 	if style == nil {
 		panic("style cannot be nil")
 	}
@@ -1135,7 +1135,7 @@ func ComputedStyle(sel interface{}, style *[]*css.ComputedStyleProperty, opts ..
 
 // MatchedStyle is an element query action that retrieves the matched style information
 // for the first element node matching the selector.
-func MatchedStyle(sel interface{}, style **css.GetMatchedStylesForNodeReturns, opts ...QueryOption) QueryAction {
+func MatchedStyle(sel any, style **css.GetMatchedStylesForNodeReturns, opts ...QueryOption) QueryAction {
 	if style == nil {
 		panic("style cannot be nil")
 	}
@@ -1161,7 +1161,7 @@ func MatchedStyle(sel interface{}, style **css.GetMatchedStylesForNodeReturns, o
 
 // ScrollIntoView is an element query action that scrolls the window to the
 // first element node matching the selector.
-func ScrollIntoView(sel interface{}, opts ...QueryOption) QueryAction {
+func ScrollIntoView(sel any, opts ...QueryOption) QueryAction {
 	return QueryAfter(sel, func(ctx context.Context, execCtx runtime.ExecutionContextID, nodes ...*cdp.Node) error {
 		if len(nodes) < 1 {
 			return fmt.Errorf("selector %q did not return any nodes", sel)

--- a/screenshot.go
+++ b/screenshot.go
@@ -29,7 +29,7 @@ import (
 // See [screenshot] for an example of taking a screenshot of the entire page.
 //
 // [screenshot]: https://github.com/chromedp/examples/tree/master/screenshot
-func Screenshot(sel interface{}, picbuf *[]byte, opts ...QueryOption) QueryAction {
+func Screenshot(sel any, picbuf *[]byte, opts ...QueryOption) QueryAction {
 	if picbuf == nil {
 		panic("picbuf cannot be nil")
 	}

--- a/target.go
+++ b/target.go
@@ -37,7 +37,7 @@ type Target struct {
 	cur cdp.FrameID
 
 	// logging funcs
-	logf, errf func(string, ...interface{})
+	logf, errf func(string, ...any)
 
 	// Indicates if the target is a worker target.
 	isWorker bool
@@ -91,7 +91,7 @@ func (t *Target) ensureFrame() (*cdp.Frame, *cdp.Node, runtime.ExecutionContextI
 func (t *Target) run(ctx context.Context) {
 	type eventValue struct {
 		method cdproto.MethodType
-		value  interface{}
+		value  any
 	}
 	// syncEventQueue is used to handle events synchronously within Target.
 	// TODO: If this queue gets full, the goroutine below could get stuck on
@@ -167,7 +167,7 @@ func (t *Target) Execute(ctx context.Context, method string, params easyjson.Mar
 	id := atomic.AddInt64(&t.browser.next, 1)
 	lctx, cancel := context.WithCancel(ctx)
 	ch := make(chan *cdproto.Message, 1)
-	fn := func(ev interface{}) {
+	fn := func(ev any) {
 		if msg, ok := ev.(*cdproto.Message); ok && msg.ID == id {
 			select {
 			case <-ctx.Done():
@@ -219,7 +219,7 @@ func (t *Target) Execute(ctx context.Context, method string, params easyjson.Mar
 }
 
 // runtimeEvent handles incoming runtime events.
-func (t *Target) runtimeEvent(ev interface{}) {
+func (t *Target) runtimeEvent(ev any) {
 	switch ev := ev.(type) {
 	case *runtime.EventExecutionContextCreated:
 		var aux struct {
@@ -289,7 +289,7 @@ func (t *Target) documentUpdated(ctx context.Context) {
 }
 
 // pageEvent handles incoming page events.
-func (t *Target) pageEvent(ev interface{}) {
+func (t *Target) pageEvent(ev any) {
 	var id cdp.FrameID
 	var op frameOp
 
@@ -359,7 +359,7 @@ func (t *Target) pageEvent(ev interface{}) {
 }
 
 // domEvent handles incoming DOM events.
-func (t *Target) domEvent(ctx context.Context, ev interface{}) {
+func (t *Target) domEvent(ctx context.Context, ev any) {
 	f := t.frames[t.cur]
 	var id cdp.NodeID
 	var op nodeOp

--- a/util.go
+++ b/util.go
@@ -104,7 +104,7 @@ func modifyURL(ctx context.Context, urlstr string) (string, error) {
 	}
 	defer resp.Body.Close()
 
-	var result map[string]interface{}
+	var result map[string]any
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		return "", err
 	}
@@ -119,7 +119,7 @@ func modifyURL(ctx context.Context, urlstr string) (string, error) {
 	return wsURL, nil
 }
 
-func runListeners(list []cancelableListener, ev interface{}) []cancelableListener {
+func runListeners(list []cancelableListener, ev any) []cancelableListener {
 	for i := 0; i < len(list); {
 		listener := list[i]
 		select {


### PR DESCRIPTION
This PR replaces `interface{}` with `any` by running the command:
```
gofmt -w -r 'interface{} -> any' .
```

`any` appears in [Go 1.18](https://tip.golang.org/doc/go1.18#language).