### PR TITLE
Improve test GitHub workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,19 +2,22 @@ on: [push, pull_request]
 name: Test
 jobs:
   test:
+    strategy:
+      matrix:
+        go-version: [1.16.x, oldstable, stable]
     runs-on: ubuntu-latest
     steps:
     - name: Install Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v4
       with:
-        go-version: 1.18.x
+        go-version: ${{ matrix.go-version }}
     - name: Install Packages
       run: |
         sudo apt-get -qq update
         sudo apt-get install -y build-essential
     - name: Checkout code
-      uses: actions/checkout@v2
-    - name: Test
-      run: |
-        TMPDIR=$RUNNER_TEMP go test -v ./...
-        ./contrib/docker-test.sh
+      uses: actions/checkout@v3
+    - name: Test Chrome
+      run: go test -v ./...
+    - name: Test headless-shell
+      run: ./contrib/docker-test.sh


### PR DESCRIPTION
This PR extends the GitHub workflow by running tests on Go 1.16.x and the 2 supported major go releases. This ensures that `chromedp` doesn't break compatibility with older Go versions, like in #1277.

Additionally:
- update `actions/setup-go` to `v4`
- update `actions/checkout` to `v3`;
- split `Test`run to `Test Chrome` and `Test headless-shell`. 