### PR TITLE
Simplify TestFileUpload by using T.TempDir and os.WriteFile

### DIFF
--- a/query_test.go
+++ b/query_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"reflect"
 	"runtime"
 	"strings"
@@ -1245,25 +1246,16 @@ func TestFileUpload(t *testing.T) {
 	s := httptest.NewServer(mux)
 	defer s.Close()
 
-	// create temporary file on disk
-	tmpfile, err := os.CreateTemp("", "chromedp-upload-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Remove(tmpfile.Name())
-	defer tmpfile.Close()
-	if _, err := tmpfile.WriteString(uploadHTML); err != nil {
-		t.Fatal(err)
-	}
-	if err := tmpfile.Close(); err != nil {
+	uploadFile := filepath.Join(t.TempDir(), "chromedp-upload-test")
+	if err := os.WriteFile(uploadFile, []byte(uploadHTML), 0o666); err != nil {
 		t.Fatal(err)
 	}
 
 	tests := []struct {
 		a Action
 	}{
-		{SendKeys(`input[name="upload"]`, tmpfile.Name(), NodeVisible)},
-		{SetUploadFiles(`input[name="upload"]`, []string{tmpfile.Name()}, NodeVisible)},
+		{SendKeys(`input[name="upload"]`, uploadFile, NodeVisible)},
+		{SetUploadFiles(`input[name="upload"]`, []string{uploadFile}, NodeVisible)},
 	}
 
 	// Don't run these tests in parallel. The only way to do so would be to


### PR DESCRIPTION
`T.TempDir` creates a new temporary directory on each call and clears it after test execution. `os.WriteFile` creates, writes, and closes a file.  By combining these functions we could write simpler test code.