### PR TITLE
deflake TestRemoteAllocator

### DIFF
--- a/allocate_test.go
+++ b/allocate_test.go
@@ -186,8 +186,8 @@ func TestRemoteAllocator(t *testing.T) {
 func testRemoteAllocator(t *testing.T, modifyURL func(wsURL string) string, wantErr string, opts []RemoteAllocatorOption) {
 	tempDir := t.TempDir()
 
-	procCtx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	procCtx, procCancel := context.WithCancel(context.Background())
+	defer procCancel()
 	cmd := exec.CommandContext(procCtx, execPath,
 		// TODO: deduplicate these with allocOpts in chromedp_test.go
 		"--no-first-run",
@@ -229,6 +229,9 @@ func testRemoteAllocator(t *testing.T, modifyURL func(wsURL string) string, want
 			if err == nil || !strings.Contains(err.Error(), wantErr) {
 				t.Fatalf("\ngot error:\n\t%v\nwant error contains:\n\t%s", err, wantErr)
 			}
+
+			procCancel()
+			cmd.Wait()
 			return
 		}
 		if err != nil {
@@ -277,16 +280,14 @@ func testRemoteAllocator(t *testing.T, modifyURL func(wsURL string) string, want
 	// TODO: a "defer cancel()" here adds a 1s timeout, since we try to
 	// close the target twice. Fix that.
 	ctx, _ := NewContext(allocCtx)
-	ctx, cancel = context.WithTimeout(ctx, 5*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
 	// Connect to the browser, then kill it.
 	if err := Run(ctx); err != nil {
 		t.Fatal(err)
 	}
-	if err := cmd.Process.Signal(os.Kill); err != nil {
-		t.Error(err)
-	}
+	procCancel()
 	switch err := Run(ctx, Navigate(testdataDir+"/form.html")); err {
 	case nil:
 		// TODO: figure out why this happens sometimes on Travis
@@ -294,6 +295,7 @@ func testRemoteAllocator(t *testing.T, modifyURL func(wsURL string) string, want
 	case context.DeadlineExceeded:
 		t.Fatalf("did not expect a standard context error: %v", err)
 	}
+	cmd.Wait()
 }
 
 func TestExecAllocatorMissingWebsocketAddr(t *testing.T) {


### PR DESCRIPTION
Most of the recent GitHub action failures show that the test `TestRemoteAllocator/NoModifyURL` is flaky. The error message looks like this:

    testing.go:958: TempDir RemoveAll cleanup: unlinkat /tmp/TestRemoteAllocatorNoModifyURL2775572114/001/Default/Code Cache/wasm: directory not empty

That's because it does not call `cmd.Wait()` to wait for the command to exit.

This commit also simplify the code to kill the command.

Updates #1105.