### PR TITLE
Fixed nil pointer exception when cancelling a context with chromedp.Cancel()

### DIFF
--- a/allocate.go
+++ b/allocate.go
@@ -87,7 +87,7 @@ var DefaultExecAllocatorOptions = [...]ExecAllocatorOption{
 // for use with NewContext.
 func NewExecAllocator(parent context.Context, opts ...ExecAllocatorOption) (context.Context, context.CancelFunc) {
 	ctx, cancel := context.WithCancel(parent)
-	c := &Context{Allocator: setupExecAllocator(opts...), cancel: cancel}
+	c := &Context{Allocator: setupExecAllocator(opts...)}
 
 	ctx = context.WithValue(ctx, contextKey{}, c)
 	cancelWait := func() {
@@ -535,9 +535,9 @@ func NewRemoteAllocator(parent context.Context, url string, opts ...RemoteAlloca
 	for _, o := range opts {
 		o(a)
 	}
+	c := &Context{Allocator: a}
 
 	ctx, cancel := context.WithCancel(parent)
-	c := &Context{Allocator: a, cancel: cancel}
 	ctx = context.WithValue(ctx, contextKey{}, c)
 	return ctx, cancel
 }

--- a/allocate.go
+++ b/allocate.go
@@ -87,7 +87,7 @@ var DefaultExecAllocatorOptions = [...]ExecAllocatorOption{
 // for use with NewContext.
 func NewExecAllocator(parent context.Context, opts ...ExecAllocatorOption) (context.Context, context.CancelFunc) {
 	ctx, cancel := context.WithCancel(parent)
-	c := &Context{Allocator: setupExecAllocator(opts...)}
+	c := &Context{Allocator: setupExecAllocator(opts...), cancel: cancel}
 
 	ctx = context.WithValue(ctx, contextKey{}, c)
 	cancelWait := func() {
@@ -535,9 +535,9 @@ func NewRemoteAllocator(parent context.Context, url string, opts ...RemoteAlloca
 	for _, o := range opts {
 		o(a)
 	}
-	c := &Context{Allocator: a}
 
 	ctx, cancel := context.WithCancel(parent)
+	c := &Context{Allocator: a, cancel: cancel}
 	ctx = context.WithValue(ctx, contextKey{}, c)
 	return ctx, cancel
 }

--- a/chromedp.go
+++ b/chromedp.go
@@ -244,6 +244,8 @@ func FromContext(ctx context.Context) *Context {
 // underlying errors happening during cancellation.
 func Cancel(ctx context.Context) error {
 	c := FromContext(ctx)
+	// c.cancel is nil when Cancel is wrongly called with a context returned
+	// by chromedp.NewExecAllocator or chromedp.NewRemoteAllocator.
 	if c == nil || c.cancel == nil {
 		return ErrInvalidContext
 	}

--- a/chromedp.go
+++ b/chromedp.go
@@ -244,7 +244,7 @@ func FromContext(ctx context.Context) *Context {
 // underlying errors happening during cancellation.
 func Cancel(ctx context.Context) error {
 	c := FromContext(ctx)
-	if c == nil {
+	if c == nil || c.cancel == nil {
 		return ErrInvalidContext
 	}
 	graceful := c.first && c.Browser != nil

--- a/chromedp_test.go
+++ b/chromedp_test.go
@@ -261,6 +261,12 @@ func TestCancelError(t *testing.T) {
 		t.Fatalf("expected a nil error, got %v", err)
 	}
 
+	allocCtx, allocCancel := NewExecAllocator(context.Background(), allocOpts...)
+	defer allocCancel()
+	if err := Cancel(allocCtx); err != ErrInvalidContext {
+		t.Fatalf("want error %q, got %q", ErrInvalidContext, err)
+	}
+
 	/*
 		// NOTE: the following test no longer is applicable, as a slight change
 		// to chromium's 89 API deprecated the boolean return value

--- a/chromedp_test.go
+++ b/chromedp_test.go
@@ -261,8 +261,6 @@ func TestCancelError(t *testing.T) {
 		t.Fatalf("expected a nil error, got %v", err)
 	}
 
-	allocCtx, allocCancel := NewExecAllocator(context.Background(), allocOpts...)
-	defer allocCancel()
 	if err := Cancel(allocCtx); err != ErrInvalidContext {
 		t.Fatalf("want error %q, got %q", ErrInvalidContext, err)
 	}


### PR DESCRIPTION
Fixes #1294 