### PR TITLE
refactor: increment, unlambda, unslice

### DIFF
--- a/allocate.go
+++ b/allocate.go
@@ -527,10 +527,8 @@ func WSURLReadTimeout(t time.Duration) ExecAllocatorOption {
 // Use chromedp.NoModifyURL to prevent it from modifying the url.
 func NewRemoteAllocator(parent context.Context, url string, opts ...RemoteAllocatorOption) (context.Context, context.CancelFunc) {
 	a := &RemoteAllocator{
-		wsURL: url,
-		modifyURLFunc: func(ctx context.Context, wsURL string) (string, error) {
-			return modifyURL(ctx, wsURL)
-		},
+		wsURL:         url,
+		modifyURLFunc: modifyURL,
 	}
 	for _, o := range opts {
 		o(a)

--- a/allocate_test.go
+++ b/allocate_test.go
@@ -456,7 +456,7 @@ func TestStartsWithNonBlankTab(t *testing.T) {
 	t.Parallel()
 
 	allocCtx, cancel := NewExecAllocator(context.Background(),
-		append(allocOpts[:],
+		append(allocOpts,
 			ModifyCmdFunc(func(cmd *exec.Cmd) {
 				// it assumes that the last argument is "about:blank" and
 				// replace it with other URL.

--- a/chromedp_test.go
+++ b/chromedp_test.go
@@ -138,8 +138,7 @@ func testAllocateSeparate(tb testing.TB) (context.Context, context.CancelFunc) {
 		tb.Fatal(err)
 	}
 	ListenBrowser(ctx, func(ev interface{}) {
-		switch ev := ev.(type) {
-		case *runtime.EventExceptionThrown:
+		if ev, ok := ev.(*runtime.EventExceptionThrown); ok {
 			tb.Errorf("%+v\n", ev.ExceptionDetails)
 		}
 	})

--- a/query_test.go
+++ b/query_test.go
@@ -227,7 +227,7 @@ func TestRetryInterval(t *testing.T) {
 			// only after the number of result nodes >= s.exp .
 			count := WaitFunc(
 				func(ctx context.Context, f *cdp.Frame, eci cdpruntime.ExecutionContextID, ni ...cdp.NodeID) ([]*cdp.Node, error) {
-					retryCount += 1
+					retryCount++
 					return nil, ErrInvalidTarget
 				},
 			)


### PR DESCRIPTION
This PR simplifies code:

- `x++` instead of `x += 1`;
- `allocOpts` instead of `allocOpts[:]`;
- `modifyURL` instead of `func(ctx context.Context, wsURL string) (string, error) { return modifyURL(ctx, wsURL)}`;
- `if` instead of `switch` for type conversion.