### PR TITLE
Discard search results if no nodes are found

### DIFF
--- a/query.go
+++ b/query.go
@@ -329,6 +329,10 @@ func BySearch(s *Selector) {
 			return nil, err
 		}
 
+		defer func() {
+			_ = dom.DiscardSearchResults(id).Do(ctx)
+		}()
+
 		if count < 1 {
 			return []cdp.NodeID{}, nil
 		}


### PR DESCRIPTION
The docs are not very clear on this, but I think the search results should be discarded if `getSearchResults` is not going to be called in order to free up the result in Chrome.