### PR TITLE
Fixing typo in allocate test

### DIFF
--- a/allocate_test.go
+++ b/allocate_test.go
@@ -157,11 +157,11 @@ func TestRemoteAllocator(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				_, post, err := net.SplitHostPort(u.Host)
+				_, port, err := net.SplitHostPort(u.Host)
 				if err != nil {
 					t.Fatal(err)
 				}
-				u.Host = net.JoinHostPort(h, post)
+				u.Host = net.JoinHostPort(h, port)
 				u.Path = "/"
 				return u.String()
 			},


### PR DESCRIPTION
This is super minor, but I stumbled when reading the code here.