### PR TITLE
Rely on AtLeast query option to check for min no of nodes

### DIFF
--- a/query.go
+++ b/query.go
@@ -859,10 +859,6 @@ func AttributesAll(sel interface{}, attributes *[]map[string]string, opts ...Que
 	}
 
 	return QueryAfter(sel, func(ctx context.Context, execCtx runtime.ExecutionContextID, nodes ...*cdp.Node) error {
-		if len(nodes) < 1 {
-			return fmt.Errorf("selector %q did not return any nodes", sel)
-		}
-
 		for _, node := range nodes {
 			node.RLock()
 			m := make(map[string]string)


### PR DESCRIPTION
Use case: I want to get attributes of elements but don't care if nothing matches. With existing hardcoded minimum requirement, it's not possible and I have to do an extra step of checking before using `AttributesAll`.