### PR TITLE
Added page.EventDownloadProgress to ignored cases in target.go

### DIFF
--- a/target.go
+++ b/target.go
@@ -246,6 +246,8 @@ func (t *Target) pageEvent(ev interface{}) {
 		return
 	case *page.EventDownloadWillBegin:
 		return
+	case *page.EventDownloadProgress:
+		return
 
 	default:
 		t.errf("unhandled page event %T", ev)


### PR DESCRIPTION
Adding EventDownloadProgress to events which are ignored in the case enumeration to avoid getting spammed with errors while a download is progressing.