### PR TITLE
Add a Github Action that will validate that latest headless shell always with docker

### DIFF
--- a/.github/workflows/validate-latest-headless-shell-with-docker.yml
+++ b/.github/workflows/validate-latest-headless-shell-with-docker.yml
@@ -32,7 +32,7 @@ jobs:
       run: docker run -d -t --name chromedp-125.0.6422.142 chromedp/headless-shell:125.0.6422.142
 
     - name: Grep for network v125.0.6422.142 is listening on
-      run: docker exec -it chromedp-125.0.6422.142 bash -c 'apt -qq update && apt install -qq -y iproute2 > /dev/null 2>&1 && ss -a | grep 9222'
+      run: docker exec chromedp-125.0.6422.142 bash -c 'apt -qq update && apt install -qq -y iproute2 > /dev/null 2>&1 && ss -a | grep 9222'
 
     - name: Curl to v125.0.6422.142 of headless-shell
       run: curl -v http://localhost:9222/json/version
@@ -46,7 +46,7 @@ jobs:
       run: docker run -d -t --name chromedp-latest chromedp/headless-shell:latest
 
     - name: Grep for network vlatest is listening on
-      run: docker exec -it chromedp-latest bash -c 'apt -qq update && apt install -qq -y iproute2 > /dev/null 2>&1 && ss -a | grep 9222'
+      run: docker exec chromedp-latest bash -c 'apt -qq update && apt install -qq -y iproute2 > /dev/null 2>&1 && ss -a | grep 9222'
 
     - name: Curl to latest headless-shell - we expect this to fail
       run: curl -v http://localhost:9222/json/version

--- a/.github/workflows/validate-latest-headless-shell-with-docker.yml
+++ b/.github/workflows/validate-latest-headless-shell-with-docker.yml
@@ -37,11 +37,6 @@ jobs:
     - name: Curl to v125.0.6422.142 of headless-shell
       run: curl -v http://localhost:9222/json/version
 
-    - name: Stop chromedp-125.0.6422.142
-      run: |
-          docker stop chromedp-125.0.6422.142
-          docker rm chromedp-125.0.6422.142
-
     - name: Start headless-shell at latest
       run: docker run -d -t --name chromedp-latest chromedp/headless-shell:latest
 

--- a/.github/workflows/validate-latest-headless-shell-with-docker.yml
+++ b/.github/workflows/validate-latest-headless-shell-with-docker.yml
@@ -1,0 +1,60 @@
+name: Validate that using docker always works with the latest headless shell
+
+on:
+  push:
+    branches:
+      - master
+      - PR/** # Build on any branch named PR/<something> from https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushbranchestagsbranches-ignoretags-ignore
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go:
+        - '1.22.3'
+    env:
+      GO111MODULE: "on"
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '${{ matrix.go }}'
+
+    - name: Print docker version
+      run: docker version
+
+    - name: Start headless-shell v125.0.6422.142
+      run: docker run -d -t --name chromedp-125.0.6422.142 chromedp/headless-shell:125.0.6422.142
+
+    - name: Grep for network v125.0.6422.142 is listening on
+      run: docker exec -it chromedp-125.0.6422.142 bash -c 'apt -qq update && apt install -qq -y iproute2 > /dev/null 2>&1 && ss -a | grep 9222'
+
+    - name: Curl to v125.0.6422.142 of headless-shell
+      run: curl -v http://localhost:9222/json/version
+
+    - name: Stop chromedp-125.0.6422.142
+        run: |
+          docker stop chromedp-125.0.6422.142
+          docker rm chromedp-125.0.6422.142
+
+    - name: Start headless-shell at latest
+      run: docker run -d -t --name chromedp-latest chromedp/headless-shell:latest
+
+    - name: Grep for network vlatest is listening on
+      run: docker exec -it chromedp-latest bash -c 'apt -qq update && apt install -qq -y iproute2 > /dev/null 2>&1 && ss -a | grep 9222'
+
+    - name: Curl to latest headless-shell - we expect this to fail
+      run: curl -v http://localhost:9222/json/version
+
+    - name: Stop containers
+      if: always()
+      run: |
+        docker stop chromedp-125.0.6422.142
+        docker rm chromedp-125.0.6422.142
+        docker stop chromedp-latest
+        docker rm chromedp-latest

--- a/.github/workflows/validate-latest-headless-shell-with-docker.yml
+++ b/.github/workflows/validate-latest-headless-shell-with-docker.yml
@@ -38,7 +38,7 @@ jobs:
       run: curl -v http://localhost:9222/json/version
 
     - name: Stop chromedp-125.0.6422.142
-        run: |
+      run: |
           docker stop chromedp-125.0.6422.142
           docker rm chromedp-125.0.6422.142
 

--- a/.github/workflows/validate-latest-headless-shell-with-docker.yml
+++ b/.github/workflows/validate-latest-headless-shell-with-docker.yml
@@ -37,6 +37,12 @@ jobs:
     - name: Curl to v125.0.6422.142 of headless-shell
       run: curl -v http://localhost:9222/json/version
 
+    - name: Stop chromedp-125.0.6422.142 containers
+      if: always()
+      run: |
+        docker stop chromedp-125.0.6422.142
+        docker rm chromedp-125.0.6422.142
+
     - name: Start headless-shell at latest
       run: docker run -d -t -p 9222:9222 --name chromedp-latest chromedp/headless-shell:latest
 
@@ -46,10 +52,8 @@ jobs:
     - name: Curl to latest headless-shell - we expect this to fail
       run: curl -v http://localhost:9222/json/version
 
-    - name: Stop containers
+    - name: Stop chromedp-latest containers
       if: always()
       run: |
-        docker stop chromedp-125.0.6422.142
-        docker rm chromedp-125.0.6422.142
         docker stop chromedp-latest
         docker rm chromedp-latest

--- a/.github/workflows/validate-latest-headless-shell-with-docker.yml
+++ b/.github/workflows/validate-latest-headless-shell-with-docker.yml
@@ -29,7 +29,7 @@ jobs:
       run: docker version
 
     - name: Start headless-shell v125.0.6422.142
-      run: docker run -d -t --name chromedp-125.0.6422.142 chromedp/headless-shell:125.0.6422.142
+      run: docker run -d -t -p 9222:9222 --name chromedp-125.0.6422.142 chromedp/headless-shell:125.0.6422.142
 
     - name: Grep for network v125.0.6422.142 is listening on
       run: docker exec chromedp-125.0.6422.142 bash -c 'apt -qq update && apt install -qq -y iproute2 > /dev/null 2>&1 && ss -a | grep 9222'
@@ -38,7 +38,7 @@ jobs:
       run: curl -v http://localhost:9222/json/version
 
     - name: Start headless-shell at latest
-      run: docker run -d -t --name chromedp-latest chromedp/headless-shell:latest
+      run: docker run -d -t -p 9222:9222 --name chromedp-latest chromedp/headless-shell:latest
 
     - name: Grep for network vlatest is listening on
       run: docker exec chromedp-latest bash -c 'apt -qq update && apt install -qq -y iproute2 > /dev/null 2>&1 && ss -a | grep 9222'


### PR DESCRIPTION
See: Issue #1476 

This github action clearly demonstrates the failure mode running the latest `headless-shell` release with docker.

It also clearly shows that release 125.0.6422.142 works using docker.

As per the comments from Brad Peabody in #1476, the latest release listens on `localhost:9222` where as release 125.0.6422.142 listens on `0.0.0.0:9222`. This github actions shows exactly the same behaviour - i.e. the newer release is listening on the wrong network.

As sample run can be seen in my fork:

https://github.com/owenwaller/chromedp/actions/runs/9548695344/job/26316470829

