### PR TITLE
fix: do not error on pings

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -78,7 +78,21 @@ func (c *Conn) Read(_ context.Context, msg *cdproto.Message) error {
 	if err != nil {
 		return err
 	}
-	if h.OpCode != ws.OpText {
+
+	if h.OpCode == ws.OpPing { // ping
+		if c.dbgf != nil {
+			c.dbgf("received ping frame, ignoring...")
+		}
+		return nil
+	} else if h.OpCode == ws.OpClose { // close
+		if c.dbgf != nil {
+			c.dbgf("received close frame")
+		}
+		return io.EOF
+	} else if h.OpCode != ws.OpText {
+		if c.dbgf != nil {
+			c.dbgf("unknown OpCode: %s", h.OpCode)
+		}
 		return ErrInvalidWebsocketMessage
 	}
 


### PR DESCRIPTION
Some CDP servers send websocket ping requests. This PR handles such pings, so the code won't error. Also added support for close frames.