### PR TITLE
CI: drop 1.16 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.16.x, oldstable, stable]
+        go-version: [oldstable, stable]
     runs-on: ubuntu-latest
     steps:
     - name: Install Go


### PR DESCRIPTION
This PR fixes failing pipeline:

<img width="651" alt="image" src="https://github.com/user-attachments/assets/dde4313e-8b70-4652-84d4-318bb7321707" />
