### PR TITLE
fix: add page.EventFrameStartedNavigating to ignored events (Google Chrome 134.x)

### DIFF
--- a/target.go
+++ b/target.go
@@ -333,7 +333,8 @@ func (t *Target) pageEvent(ev any) {
 		*page.EventScreencastVisibilityChanged,
 		*page.EventWindowOpen,
 		*page.EventBackForwardCacheNotUsed,
-		*page.EventFrameSubtreeWillBeDetached:
+		*page.EventFrameSubtreeWillBeDetached,
+		*page.EventFrameStartedNavigating:
 		return
 
 	default:


### PR DESCRIPTION
Hey 👋 

Since Google Chrome 134.x (amd64), [I get a lot of errors logs](https://github.com/gotenberg/gotenberg/issues/1139):

```
ERROR: unhandled page event *page.EventFrameStartedNavigating
```

I wonder if it should be handled somehow 🤔 