### PR TITLE
Add default json config to enable decoding / encoding messages with illegal utf-8

### DIFF
--- a/browser.go
+++ b/browser.go
@@ -208,7 +208,7 @@ func (b *Browser) execute(ctx context.Context, method string, params, res any) e
 	var buf []byte
 	if params != nil {
 		var err error
-		if buf, err = jsonv2.Marshal(params); err != nil {
+		if buf, err = jsonv2.Marshal(params, DefaultMarshalOptions); err != nil {
 			return err
 		}
 	}

--- a/browser_test.go
+++ b/browser_test.go
@@ -1,0 +1,85 @@
+package chromedp
+
+import (
+	"bytes"
+	"github.com/chromedp/cdproto"
+	jsonv2 "github.com/go-json-experiment/json"
+	"github.com/go-json-experiment/json/jsontext"
+	"testing"
+)
+
+func TestUnmarshalWithDefaultOptions(t *testing.T) {
+	tests := []struct {
+		Name      string
+		Input     []byte
+		WantError bool
+	}{
+		{Name: "simple json", Input: []byte(`{"id":1, "result": {"bar":"foo"}}`), WantError: false},
+		{Name: "invalid utf-8 1", Input: []byte(`{"id":2, "result": "\udebe\\u018e8"}`), WantError: false},
+		{Name: "invalid utf-8 2", Input: []byte(`{"id":2, "result": "y7vzPw=T6\u001a\u053a{\ud861=\u001b"}`), WantError: false},
+		{Name: "empty json", Input: []byte(`{}`), WantError: false},
+		{Name: "null result", Input: []byte(`{"id":4, "result": null}`), WantError: false},
+		{Name: "nested json", Input: []byte(`{"id":5, "result": {"nested": {"foo": "bar"}}}`), WantError: false},
+		{Name: "array in result", Input: []byte(`{"id":6, "result": ["foo", "bar"]}`), WantError: false},
+		{Name: "boolean in result", Input: []byte(`{"id":7, "result": true}`), WantError: false},
+		{Name: "number in result", Input: []byte(`{"id":8, "result": 12345}`), WantError: false},
+		{Name: "string in result", Input: []byte(`{"id":9, "result": "foobar"}`), WantError: false},
+		{Name: "extra fields", Input: []byte(`{"id":10, "result": {"bar":"foo"}, "extra": "field"}`), WantError: false},
+		{Name: "invalid json", Input: []byte(`{"id":11, "result": {"bar":"foo"`), WantError: true},
+		{Name: "empty input", Input: []byte(``), WantError: true},
+		{Name: "whitespace input", Input: []byte(`   `), WantError: true},
+		{Name: "null input", Input: nil, WantError: true},
+	}
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			var decoder jsontext.Decoder
+			var b bytes.Buffer
+			b.Write(test.Input)
+			var msg cdproto.Message
+			decoder.Reset(&b, DefaultUnmarshalOptions)
+			err := jsonv2.UnmarshalDecode(&decoder, &msg, DefaultUnmarshalOptions)
+			if test.WantError && err == nil {
+				t.Error("expected error in unmarshal decode, but got none")
+			} else if !test.WantError && err != nil {
+				t.Errorf("expected no error in unmarshal decode, but got %s", err)
+			}
+			err = jsonv2.Unmarshal(test.Input, &msg, DefaultUnmarshalOptions)
+			if test.WantError && err == nil {
+				t.Error("expected error, but got none")
+			} else if !test.WantError && err != nil {
+				t.Errorf("expected no error, but got %s", err)
+			}
+		})
+	}
+}
+
+func TestMarshalWithDefaultOptions(t *testing.T) {
+	tests := []struct {
+		Name      string
+		Input     cdproto.Message
+		WantError bool
+	}{
+		{Name: "simple json", Input: cdproto.Message{Result: []byte(`{"bar":"foo"}`)}, WantError: false},
+		{Name: "invalid utf-8 1", Input: cdproto.Message{Result: []byte(`"\udebe\\u018e8"`)}, WantError: false},
+		{Name: "invalid utf-8 2", Input: cdproto.Message{Result: []byte(`"y7vzPw=T6\u001a\u053a{\ud861=\u001b"`)}, WantError: false},
+	}
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			var encoder jsontext.Encoder
+			var b bytes.Buffer
+			encoder.Reset(&b, DefaultMarshalOptions)
+			err := jsonv2.MarshalEncode(&encoder, &test.Input, DefaultMarshalOptions)
+			if test.WantError && err == nil {
+				t.Error("expected error in marshal encode, but got none")
+			} else if !test.WantError && err != nil {
+				t.Errorf("expected no error in marshal encode, but got %s", err)
+			}
+			_, err = jsonv2.Marshal(test.Input, DefaultMarshalOptions)
+			if test.WantError && err == nil {
+				t.Error("expected error, but got none")
+			} else if !test.WantError && err != nil {
+				t.Errorf("expected no error, but got %s", err)
+			}
+		})
+	}
+}

--- a/conn.go
+++ b/conn.go
@@ -105,8 +105,8 @@ func (c *Conn) Read(_ context.Context, msg *cdproto.Message) error {
 	}
 
 	// unmarshal, reusing decoder
-	c.decoder.Reset(&b)
-	return jsonv2.UnmarshalDecode(&c.decoder, msg)
+	c.decoder.Reset(&b, DefaultUnmarshalOptions)
+	return jsonv2.UnmarshalDecode(&c.decoder, msg, DefaultUnmarshalOptions)
 }
 
 // Write writes a message.
@@ -126,7 +126,7 @@ func (c *Conn) Write(_ context.Context, msg *cdproto.Message) error {
 
 	// Perform marshal, reusing encoder
 	var b bytes.Buffer
-	c.encoder.Reset(&b)
+	c.encoder.Reset(&b, DefaultMarshalOptions)
 	if err := jsonv2.MarshalEncode(&c.encoder, msg, DefaultMarshalOptions); err != nil {
 		return err
 	}

--- a/target.go
+++ b/target.go
@@ -114,7 +114,7 @@ func (t *Target) run(ctx context.Context) {
 					t.listenersMu.Unlock()
 					continue
 				}
-				ev, err := cdproto.UnmarshalMessage(msg)
+				ev, err := cdproto.UnmarshalMessage(msg, DefaultUnmarshalOptions)
 				if err != nil {
 					if _, ok := err.(cdp.ErrUnknownCommandOrEvent); ok {
 						// This is most likely an event received from an older
@@ -210,7 +210,7 @@ func (t *Target) Execute(ctx context.Context, method string, params, res any) er
 		case msg.Error != nil:
 			return msg.Error
 		case res != nil:
-			return jsonv2.Unmarshal(msg.Result, res)
+			return jsonv2.Unmarshal(msg.Result, res, DefaultUnmarshalOptions)
 		}
 	}
 	return nil


### PR DESCRIPTION
The fix for handling illegal utf-8 when decoding / encoding json that were introduce in `chromedp` 0.13.2 had some gaps where the config wasn't set in all scenarios. 

This pull requests fixes that by setting the config and also adds tests to make sure future updates to json2 doesn't reintroduce this problem.  

Related issue: 
https://github.com/chromedp/cdproto/issues/29