### PR TITLE
log syntactic errors when reading messages

### DIFF
--- a/browser.go
+++ b/browser.go
@@ -259,6 +259,10 @@ func (b *Browser) run(ctx context.Context) {
 		for {
 			msg := new(cdproto.Message)
 			if err := b.conn.Read(ctx, msg); err != nil {
+				var syntacticError *jsontext.SyntacticError
+				if errors.As(err, &syntacticError) {
+					b.errf("%s", err)
+				}
 				return
 			}
 


### PR DESCRIPTION
Currently, if chromedp encounters an error decoding a message sent by chrome then it will exit silently and suppress the error. By logging syntactic errors from jsonv2 this becomes a lot easier to debug as mentioned in https://github.com/chromedp/cdproto/issues/29#issuecomment-2739804828. 

Logging all errors would be very verbose considering expected errors such as io.EOF would end up in logs. Limiting it to only syntactic errors seems like a good compromise.   