### PR TITLE
fix(allocator): Set --enable-unsafe-swiftshader with --disable-gpu

### DIFF
--- a/allocate.go
+++ b/allocate.go
@@ -491,8 +491,13 @@ func Headless(a *ExecAllocator) {
 //
 // But according to this reported issue, it's still required in some cases:
 //   - https://github.com/chromedp/chromedp/issues/904
+//
+// Chromium 139+ doesn't provide fallback to Swiftshader unless the
+// --enable-unsafe-swiftshader option is passed:
+//   - https://chromestatus.com/feature/5166674414927872
 func DisableGPU(a *ExecAllocator) {
 	Flag("disable-gpu", true)(a)
+	Flag("enable-unsafe-swiftshader", true)(a)
 }
 
 // CombinedOutput is used to set an io.Writer where stdout and stderr


### PR DESCRIPTION
In Chromium 139+, falling back to Swiftshader will be opt in:

https://chromestatus.com/feature/5166674414927872

This means that anything currently leveraging DisableGPU in chromedp will fail to fallback in the future without this flag set

This is already current behavior in upstream builds of Chromium 138

This sets --enable-unsafe-swiftshader to retain existing behavior and prevent regressions in anything using chromedp