### PR TITLE
chore: remove unused min/max func

### DIFF
--- a/screenshot.go
+++ b/screenshot.go
@@ -166,17 +166,3 @@ func extents(m, n, o, p float64) (float64, float64) {
 	b := max(m+n, o+p)
 	return a, b - a
 }
-
-func min(a, b float64) float64 {
-	if a < b {
-		return a
-	}
-	return b
-}
-
-func max(a, b float64) float64 {
-	if a > b {
-		return a
-	}
-	return b
-}


### PR DESCRIPTION
Go 1.21 adds built-in functions min and max.   https://tip.golang.org/doc/go1.21
Therefore, we can directly remove our own implementations and use the built-in function with the same names. 
