### PR TITLE
Fix incorrect parameter `site-per-process` in `disable-features`

### DIFF
--- a/allocate.go
+++ b/allocate.go
@@ -68,7 +68,7 @@ var DefaultExecAllocatorOptions = [...]ExecAllocatorOption{
 	Flag("disable-default-apps", true),
 	Flag("disable-dev-shm-usage", true),
 	Flag("disable-extensions", true),
-	Flag("disable-features", "site-per-process,Translate,BlinkGenPropertyTrees"),
+	Flag("disable-features", "SitePerProcess,Translate,BlinkGenPropertyTrees"),
 	Flag("disable-hang-monitor", true),
 	Flag("disable-ipc-flooding-protection", true),
 	Flag("disable-popup-blocking", true),


### PR DESCRIPTION
Fixes #1605

In `DefaultExecAllocatorOptions`, the `disable-features` flag currently uses `site-per-process` as a parameter. However, The correct parameter should be `SitePerProcess`