### PR TITLE
feat: add PipeAllocator for pipe-based CDP communication

### DIFF
--- a/allocate.go
+++ b/allocate.go
@@ -611,3 +611,329 @@ func (a *RemoteAllocator) Wait() {
 func NoModifyURL(a *RemoteAllocator) {
 	a.modifyURLFunc = nil
 }
+
+// PipeAllocator implements Allocator for pipe-based CDP communication.
+// This is useful for sandboxed environments (gVisor, Firecracker) where
+// runtime TCP bind/listen is restricted.
+type PipeAllocator struct {
+	execPath      string
+	initFlags     map[string]any
+	initEnv       []string
+	modifyCmdFunc func(*exec.Cmd)
+
+	wg sync.WaitGroup
+}
+
+// PipeAllocatorOption is a function that configures a PipeAllocator.
+type PipeAllocatorOption func(*PipeAllocator)
+
+// DefaultPipeAllocatorOptions are the default options for PipeAllocator.
+// Similar to DefaultExecAllocatorOptions but for pipe-based communication.
+var DefaultPipeAllocatorOptions = [...]PipeAllocatorOption{
+	PipeNoFirstRun,
+	PipeNoDefaultBrowserCheck,
+	PipeHeadless,
+
+	// After Puppeteer's default behavior.
+	PipeFlag("disable-background-networking", true),
+	PipeFlag("enable-features", "NetworkService,NetworkServiceInProcess"),
+	PipeFlag("disable-background-timer-throttling", true),
+	PipeFlag("disable-backgrounding-occluded-windows", true),
+	PipeFlag("disable-breakpad", true),
+	PipeFlag("disable-client-side-phishing-detection", true),
+	PipeFlag("disable-default-apps", true),
+	PipeFlag("disable-dev-shm-usage", true),
+	PipeFlag("disable-extensions", true),
+	PipeFlag("disable-features", "site-per-process,Translate,BlinkGenPropertyTrees"),
+	PipeFlag("disable-hang-monitor", true),
+	PipeFlag("disable-ipc-flooding-protection", true),
+	PipeFlag("disable-popup-blocking", true),
+	PipeFlag("disable-prompt-on-repost", true),
+	PipeFlag("disable-renderer-backgrounding", true),
+	PipeFlag("disable-sync", true),
+	PipeFlag("force-color-profile", "srgb"),
+	PipeFlag("metrics-recording-only", true),
+	PipeFlag("safebrowsing-disable-auto-update", true),
+	PipeFlag("enable-automation", true),
+	PipeFlag("password-store", "basic"),
+	PipeFlag("use-mock-keychain", true),
+}
+
+// NewPipeAllocator creates a new pipe-based allocator. suitable
+// for use with NewContext.
+func NewPipeAllocator(parent context.Context, opts ...PipeAllocatorOption) (context.Context, context.CancelFunc) {
+	a := &PipeAllocator{
+		initFlags: make(map[string]any),
+	}
+	for _, o := range opts {
+		o(a)
+	}
+
+	// Use findExecPath if no path specified
+	if a.execPath == "" {
+		a.execPath = findExecPath()
+	}
+
+	c := &Context{Allocator: a}
+	ctx, cancel := context.WithCancel(parent)
+	ctx = context.WithValue(ctx, contextKey{}, c)
+
+	cancelWait := func() {
+		cancel()
+		c.Allocator.Wait()
+	}
+	return ctx, cancelWait
+}
+
+// Allocate starts a new browser process with pipe-based communication.
+func (a *PipeAllocator) Allocate(ctx context.Context, opts ...BrowserOption) (*Browser, error) {
+	c := FromContext(ctx)
+	if c == nil {
+		return nil, ErrInvalidContext
+	}
+
+	// Build command line args
+	var args []string
+	for name, value := range a.initFlags {
+		switch v := value.(type) {
+		case string:
+			args = append(args, fmt.Sprintf("--%s=%s", name, v))
+		case bool:
+			if v {
+				args = append(args, fmt.Sprintf("--%s", name))
+			}
+		default:
+			return nil, fmt.Errorf("invalid pipe allocator flag type")
+		}
+	}
+
+	// Handle user-data-dir
+	removeDir := false
+	dataDir, ok := a.initFlags["user-data-dir"].(string)
+	if !ok {
+		tempDir, err := os.MkdirTemp(allocTempDir, "chromedp-pipe-")
+		if err != nil {
+			return nil, err
+		}
+		args = append(args, "--user-data-dir="+tempDir)
+		dataDir = tempDir
+		removeDir = true
+	}
+
+	// Add no-sandbox if running as root
+	if _, ok := a.initFlags["no-sandbox"]; !ok && os.Getuid() == 0 {
+		args = append(args, "--no-sandbox")
+	}
+
+	// Use pipe instead of port
+	args = append(args, "--remote-debugging-pipe")
+
+	// Force blank first page
+	args = append(args, "about:blank")
+
+	// Create pipes for CDP communication
+	// Chrome reads from FD 3, writes to FD 4
+	chromeRead, appWrite, err := os.Pipe()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create write pipe: %w", err)
+	}
+	appRead, chromeWrite, err := os.Pipe()
+	if err != nil {
+		chromeRead.Close()
+		appWrite.Close()
+		return nil, fmt.Errorf("failed to create read pipe: %w", err)
+	}
+
+	// Setup command
+	cmd := exec.CommandContext(ctx, a.execPath, args...)
+	cmd.ExtraFiles = []*os.File{chromeRead, chromeWrite} // FD 3, FD 4
+
+	if len(a.initEnv) > 0 {
+		cmd.Env = append(os.Environ(), a.initEnv...)
+	}
+
+	if a.modifyCmdFunc != nil {
+		a.modifyCmdFunc(cmd)
+	} else {
+		allocateCmdOptions(cmd)
+	}
+
+	cleanup := func() {
+		chromeRead.Close()
+		chromeWrite.Close()
+		appRead.Close()
+		appWrite.Close()
+		if removeDir {
+			os.RemoveAll(dataDir)
+		}
+	}
+
+	if err := cmd.Start(); err != nil {
+		cleanup()
+		return nil, fmt.Errorf("failed to start chrome: %w", err)
+	}
+
+	// Close Chrome's end of the pipes in our process
+	chromeRead.Close()
+	chromeWrite.Close()
+
+	pipeConn := &PipeConn{
+		reader:  bufio.NewReader(appRead),
+		writer:  appWrite,
+		readFd:  appRead,
+		writeFd: appWrite,
+	}
+
+	close(c.allocated)
+
+	browser, err := NewBrowser(ctx, "", append(opts, withConn(pipeConn))...)
+	if err != nil {
+		cmd.Process.Kill()
+		cmd.Wait()
+		appRead.Close()
+		appWrite.Close()
+		if removeDir {
+			os.RemoveAll(dataDir)
+		}
+		return nil, err
+	}
+
+	browser.process = cmd.Process
+	browser.userDataDir = dataDir
+
+	// Start cleanup goroutine. It blocks until the browser disconnects,
+	// then closes the pipe FDs, ensures the Chrome process is killed if
+	// not already shutting down gracefully, waits for process exit, and
+	// finally removes the temporary user data directory (after a short
+	// delay to let Chrome finish cleanup).
+	a.wg.Add(1)
+	go func() {
+		defer a.wg.Done()
+
+		<-browser.LostConnection
+
+		appRead.Close()
+		appWrite.Close()
+
+		select {
+		case <-browser.closingGracefully:
+		default:
+			cmd.Process.Kill()
+		}
+
+		cmd.Wait()
+
+		if removeDir {
+			<-time.After(10 * time.Millisecond)
+			if err := os.RemoveAll(dataDir); c.cancelErr == nil {
+				c.cancelErr = err
+			}
+		}
+	}()
+
+	return browser, nil
+}
+
+// Wait blocks until all browser processes have exited.
+func (a *PipeAllocator) Wait() {
+	a.wg.Wait()
+}
+
+// -----------------------------
+// PipeAllocatorOptions
+// -----------------------------
+
+// PipeExecPath sets the Chrome executable path.
+func PipeExecPath(path string) PipeAllocatorOption {
+	return func(a *PipeAllocator) {
+		// Convert to an absolute path if possible, to avoid
+		// repeated LookPath calls in each Allocate.
+		if fullPath, _ := exec.LookPath(path); fullPath != "" {
+			a.execPath = fullPath
+		} else {
+			a.execPath = path
+		}
+	}
+}
+
+// PipeFlag sets a Chrome command line flag.
+func PipeFlag(name string, value any) PipeAllocatorOption {
+	return func(a *PipeAllocator) {
+		a.initFlags[name] = value
+	}
+}
+
+// PipeUserDataDir sets the user data directory.
+func PipeUserDataDir(dir string) PipeAllocatorOption {
+	return func(a *PipeAllocator) {
+		a.initFlags["user-data-dir"] = dir
+	}
+}
+
+// PipeHeadless enables headless mode.
+func PipeHeadless(a *PipeAllocator) {
+	a.initFlags["headless"] = true
+}
+
+// PipeNoSandbox disables Chrome's sandbox.
+func PipeNoSandbox(a *PipeAllocator) {
+	a.initFlags["no-sandbox"] = true
+}
+
+// PipeDisableGPU disables GPU hardware acceleration.
+func PipeDisableGPU(a *PipeAllocator) {
+	a.initFlags["disable-gpu"] = true
+}
+
+// PipeWindowSize sets the initial window size.
+func PipeWindowSize(width, height int) PipeAllocatorOption {
+	return func(a *PipeAllocator) {
+		a.initFlags["window-size"] = fmt.Sprintf("%d,%d", width, height)
+	}
+}
+
+// PipeEnv sets environment variables for the Chrome process.
+func PipeEnv(env ...string) PipeAllocatorOption {
+	return func(a *PipeAllocator) {
+		a.initEnv = append(a.initEnv, env...)
+	}
+}
+
+// PipeModifyCmdFunc sets a function to modify the exec.Cmd before starting.
+func PipeModifyCmdFunc(fn func(*exec.Cmd)) PipeAllocatorOption {
+	return func(a *PipeAllocator) {
+		a.modifyCmdFunc = fn
+	}
+}
+
+// PipeDisableDevShmUsage disables /dev/shm usage (useful in containers).
+func PipeDisableDevShmUsage(a *PipeAllocator) {
+	a.initFlags["disable-dev-shm-usage"] = true
+}
+
+// PipeNoFirstRun disables first run experience.
+func PipeNoFirstRun(a *PipeAllocator) {
+	a.initFlags["no-first-run"] = true
+}
+
+// PipeNoDefaultBrowserCheck disables default browser check.
+func PipeNoDefaultBrowserCheck(a *PipeAllocator) {
+	a.initFlags["no-default-browser-check"] = true
+}
+
+// PipeProxyServer sets the proxy server.
+func PipeProxyServer(proxy string) PipeAllocatorOption {
+	return func(a *PipeAllocator) {
+		a.initFlags["proxy-server"] = proxy
+	}
+}
+
+// PipeDisableExtensions disables extensions.
+func PipeDisableExtensions(a *PipeAllocator) {
+	a.initFlags["disable-extensions"] = true
+}
+
+// PipeIgnoreCertificateErrors ignores certificate errors.
+func PipeIgnoreCertificateErrors(a *PipeAllocator) {
+	a.initFlags["ignore-certificate-errors"] = true
+}

--- a/allocate_test.go
+++ b/allocate_test.go
@@ -511,3 +511,212 @@ func TestStartsWithNonBlankTab(t *testing.T) {
 		}
 	}
 }
+
+func TestPipeAllocator(t *testing.T) {
+	t.Parallel()
+
+	allocCtx, allocCancel := NewPipeAllocator(context.Background(), pipeAllocOpts...)
+
+	taskCtx, cancel := NewContext(allocCtx)
+	defer cancel()
+
+	want := "insert"
+	var got string
+	if err := Run(taskCtx,
+		Navigate(testdataDir+"/form.html"),
+		Text("#foo", &got, ByID),
+	); err != nil {
+		allocCancel()
+		t.Fatal(err)
+	}
+	if got != want {
+		allocCancel()
+		t.Fatalf("want %q, got %q", want, got)
+	}
+
+	cancel()
+	allocCancel()
+
+	tempDir := FromContext(taskCtx).Browser.userDataDir
+	if _, err := os.Lstat(tempDir); !os.IsNotExist(err) {
+		t.Fatalf("temporary user data dir %q not deleted", tempDir)
+	}
+}
+
+func TestPipeAllocatorCancelParent(t *testing.T) {
+	t.Parallel()
+
+	allocCtx, allocCancel := NewPipeAllocator(context.Background(), pipeAllocOpts...)
+	defer allocCancel()
+
+	taskCtx, _ := NewContext(allocCtx)
+	if err := Run(taskCtx); err != nil {
+		t.Fatal(err)
+	}
+
+	allocCancel()
+
+	tempDir := FromContext(taskCtx).Browser.userDataDir
+	if _, err := os.Lstat(tempDir); !os.IsNotExist(err) {
+		t.Fatalf("temporary user data dir %q not deleted", tempDir)
+	}
+}
+
+func TestPipeAllocatorUserDataDir(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	allocCtx, cancel := NewPipeAllocator(context.Background(),
+		append([]PipeAllocatorOption{PipeUserDataDir(dir)}, pipeAllocOpts...)...)
+	defer cancel()
+
+	taskCtx, cancel := NewContext(allocCtx)
+	defer cancel()
+
+	want := "insert"
+	var got string
+	if err := Run(taskCtx,
+		Navigate(testdataDir+"/form.html"),
+		Text("#foo", &got, ByID),
+	); err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("want %q, got %q", want, got)
+	}
+}
+
+func TestPipeAllocatorEnv(t *testing.T) {
+	t.Parallel()
+
+	tz := "Australia/Melbourne"
+	allocCtx, cancel := NewPipeAllocator(context.Background(),
+		append([]PipeAllocatorOption{
+			PipeEnv("TZ=" + tz),
+		}, pipeAllocOpts...)...)
+	defer cancel()
+
+	taskCtx, cancel := NewContext(allocCtx)
+	defer cancel()
+
+	var ret string
+	if err := Run(taskCtx,
+		Evaluate(`Intl.DateTimeFormat().resolvedOptions().timeZone`, &ret),
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	if ret != tz {
+		t.Fatalf("got %s, want %s", ret, tz)
+	}
+}
+
+func TestPipeAllocatorMultipleTabs(t *testing.T) {
+	t.Parallel()
+
+	allocCtx, cancel := NewPipeAllocator(context.Background(), pipeAllocOpts...)
+	defer cancel()
+
+	taskCtx, cancel := NewContext(allocCtx)
+	defer cancel()
+
+	// First tab
+	want := "insert"
+	var got string
+	if err := Run(taskCtx,
+		Navigate(testdataDir+"/form.html"),
+		Text("#foo", &got, ByID),
+	); err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("first tab: want %q, got %q", want, got)
+	}
+
+	// Second tab
+	tabCtx, cancel := NewContext(taskCtx)
+	defer cancel()
+
+	var got2 string
+	if err := Run(tabCtx,
+		Navigate(testdataDir+"/form.html"),
+		Text("#foo", &got2, ByID),
+	); err != nil {
+		t.Fatal(err)
+	}
+	if got2 != want {
+		t.Fatalf("second tab: want %q, got %q", want, got2)
+	}
+}
+
+// In pipe mode, Chrome's subprocesses can hold pipe file descriptors open even
+// after the main browser process is killed. Because the connection isn't closed
+// immediately, chromedp's Navigate hangs until the provided context times out.
+// This is expected behavior for abrupt kills in pipe mode, not an allocator bug.
+func TestPipeAllocatorKillBrowser(t *testing.T) {
+	t.Parallel()
+
+	allocCtx, allocCancel := NewPipeAllocator(context.Background(), pipeAllocOpts...)
+	defer allocCancel()
+
+	taskCtx, cancel := NewContext(allocCtx)
+	defer cancel()
+
+	ctx, cancel := context.WithTimeout(taskCtx, 3*time.Second)
+	defer cancel()
+
+	kill := make(chan struct{}, 1)
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		kill <- struct{}{}
+		<-ctx.Done()
+	}))
+	defer s.Close()
+
+	go func() {
+		<-kill
+		b := FromContext(ctx).Browser
+		if err := b.process.Signal(os.Kill); err != nil {
+			t.Error(err)
+		}
+	}()
+
+	err := Run(ctx, Navigate(s.URL))
+	if err == nil {
+		return
+	}
+
+	if errors.Is(err, context.DeadlineExceeded) {
+		t.Log("browser killed forcefully; received timeout (acceptable in pipe mode)")
+		return
+	}
+
+	t.Logf("browser killed, got error: %v", err)
+}
+
+func TestPipeAllocatorModifyCmdFunc(t *testing.T) {
+	t.Parallel()
+
+	tz := "Atlantic/Reykjavik"
+	allocCtx, cancel := NewPipeAllocator(context.Background(),
+		append([]PipeAllocatorOption{
+			PipeModifyCmdFunc(func(cmd *exec.Cmd) {
+				cmd.Env = append(cmd.Env, "TZ="+tz)
+			}),
+		}, pipeAllocOpts...)...)
+	defer cancel()
+
+	taskCtx, cancel := NewContext(allocCtx)
+	defer cancel()
+
+	var ret string
+	if err := Run(taskCtx,
+		Evaluate(`Intl.DateTimeFormat().resolvedOptions().timeZone`, &ret),
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	if ret != tz {
+		t.Fatalf("got %s, want %s", ret, tz)
+	}
+}

--- a/browser.go
+++ b/browser.go
@@ -114,17 +114,19 @@ func NewBrowser(ctx context.Context, urlstr string, opts ...BrowserOption) (*Bro
 		b.errf = func(s string, v ...any) { b.logf("ERROR: "+s, v...) }
 	}
 
-	dialCtx := ctx
-	if b.dialTimeout > 0 {
-		var cancel context.CancelFunc
-		dialCtx, cancel = context.WithTimeout(ctx, b.dialTimeout)
-		defer cancel()
-	}
+	if b.conn == nil {
+		dialCtx := ctx
+		if b.dialTimeout > 0 {
+			var cancel context.CancelFunc
+			dialCtx, cancel = context.WithTimeout(ctx, b.dialTimeout)
+			defer cancel()
+		}
 
-	var err error
-	b.conn, err = DialContext(dialCtx, urlstr, WithConnDebugf(b.dbgf))
-	if err != nil {
-		return nil, fmt.Errorf("could not dial %q: %w", urlstr, err)
+		var err error
+		b.conn, err = DialContext(dialCtx, urlstr, WithConnDebugf(b.dbgf))
+		if err != nil {
+			return nil, fmt.Errorf("could not dial %q: %w", urlstr, err)
+		}
 	}
 
 	go b.run(ctx)
@@ -373,4 +375,11 @@ func WithConsolef(f func(string, ...any)) BrowserOption {
 // to not use a timeout.
 func WithDialTimeout(d time.Duration) BrowserOption {
 	return func(b *Browser) { b.dialTimeout = d }
+}
+
+
+// WithConn is a browser option to provide a pre-established connection.
+// Used by PipeAllocator for pipe-based CDP communication.
+func withConn(conn Transport) BrowserOption {
+	return func(b *Browser) { b.conn = conn }
 }

--- a/pipe_conn.go
+++ b/pipe_conn.go
@@ -1,0 +1,85 @@
+package chromedp
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"os"
+	"sync"
+
+	"github.com/chromedp/cdproto"
+	jsonv2 "github.com/go-json-experiment/json"
+	"github.com/go-json-experiment/json/jsontext"
+)
+
+// PipeConn implements Transport for pipe-based CDP communication.
+// It is used when Chrome is started with the --remote-debugging-pipe
+// which expose FD 3 (stdin) and FD 4 (stdout) for bidirectional CDP messaging.
+// Unlike the WebSocket transport, this mode uses an ASCIIZ encoding:
+// each JSON message is followed by a null byte (0x00) as the terminator.
+type PipeConn struct {
+	reader  *bufio.Reader
+	writer  *os.File
+	readFd  *os.File
+	writeFd *os.File
+
+	writeMu sync.Mutex
+
+	decoder jsontext.Decoder
+	encoder jsontext.Encoder
+
+	debugf func(string, ...any)
+}
+
+// Read reads a CDP message from Chrome (from FD 4).
+// Messages are null-byte terminated in ASCIIZ mode.
+func (p *PipeConn) Read(_ context.Context, msg *cdproto.Message) error {
+	data, err := p.reader.ReadBytes(0)
+	if err != nil {
+		return err
+	}
+
+	// Strip the null terminator
+	if len(data) > 0 {
+		data = data[:len(data)-1]
+	}
+
+	if p.debugf != nil {
+		p.debugf("<- %s", data)
+	}
+
+	p.decoder.Reset(bytes.NewReader(data), DefaultUnmarshalOptions)
+	return jsonv2.UnmarshalDecode(&p.decoder, msg, DefaultUnmarshalOptions)
+}
+
+// Write writes a CDP message to Chrome (to FD 3).
+// Messages are null-byte terminated in ASCIIZ mode.
+func (p *PipeConn) Write(_ context.Context, msg *cdproto.Message) error {
+	p.writeMu.Lock()
+	defer p.writeMu.Unlock()
+
+	var b bytes.Buffer
+	p.encoder.Reset(&b, DefaultMarshalOptions)
+	if err := jsonv2.MarshalEncode(&p.encoder, msg, DefaultMarshalOptions); err != nil {
+		return err
+	}
+
+	if p.debugf != nil {
+		p.debugf("-> %s", b.Bytes())
+	}
+
+	if _, err := p.writer.Write(b.Bytes()); err != nil {
+		return err
+	}
+	_, err := p.writer.Write([]byte{0})
+	return err
+}
+
+func (p *PipeConn) Close() error {
+	err1 := p.readFd.Close()
+	err2 := p.writeFd.Close()
+	if err1 != nil {
+		return err1
+	}
+	return err2
+}

--- a/pipe_conn_test.go
+++ b/pipe_conn_test.go
@@ -1,0 +1,379 @@
+package chromedp
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/chromedp/cdproto"
+)
+
+func TestPipeConnReadWrite(t *testing.T) {
+	t.Parallel()
+
+	// Create pipe pair to simulate Chrome connection
+	readFd, writeFd, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer readFd.Close()
+	defer writeFd.Close()
+
+	conn := &PipeConn{
+		reader:  bufio.NewReader(readFd),
+		writer:  writeFd,
+		readFd:  readFd,
+		writeFd: writeFd,
+	}
+
+	// Test Write
+	msg := &cdproto.Message{
+		ID:     1,
+		Method: "Test.method",
+	}
+
+	// Write in goroutine since pipe blocks
+	go func() {
+		if err := conn.Write(context.Background(), msg); err != nil {
+			t.Error(err)
+		}
+	}()
+
+	// Read raw bytes to verify format
+	var buf bytes.Buffer
+	for {
+		b := make([]byte, 1)
+		_, err := readFd.Read(b)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if b[0] == 0 {
+			break // null terminator
+		}
+		buf.WriteByte(b[0])
+	}
+
+	got := buf.String()
+	if !bytes.Contains([]byte(got), []byte(`"id":1`)) {
+		t.Fatalf("expected id:1 in output, got %s", got)
+	}
+	if !bytes.Contains([]byte(got), []byte(`"method":"Test.method"`)) {
+		t.Fatalf("expected method in output, got %s", got)
+	}
+}
+
+func TestPipeConnRead(t *testing.T) {
+	t.Parallel()
+
+	readFd, writeFd, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer readFd.Close()
+	defer writeFd.Close()
+
+	conn := &PipeConn{
+		reader:  bufio.NewReader(readFd),
+		writer:  writeFd,
+		readFd:  readFd,
+		writeFd: writeFd,
+	}
+
+	// Simulate Chrome sending a message (null-terminated JSON)
+	go func() {
+		data := []byte(`{"id":42,"result":{"foo":"bar"}}`)
+		writeFd.Write(data)
+		writeFd.Write([]byte{0}) // null terminator
+	}()
+
+	var msg cdproto.Message
+	if err := conn.Read(context.Background(), &msg); err != nil {
+		t.Fatal(err)
+	}
+
+	if msg.ID != 42 {
+		t.Fatalf("want id 42, got %d", msg.ID)
+	}
+}
+
+func TestPipeConnClose(t *testing.T) {
+	t.Parallel()
+
+	readFd, writeFd, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	conn := &PipeConn{
+		reader:  bufio.NewReader(readFd),
+		writer:  writeFd,
+		readFd:  readFd,
+		writeFd: writeFd,
+	}
+
+	if err := conn.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = readFd.Read(make([]byte, 1))
+	if err == nil {
+		t.Fatal("expected an error after closing readFd, got nil")
+	}
+
+	if !errors.Is(err, os.ErrClosed) && err != io.EOF && !strings.Contains(err.Error(), "closed") {
+		t.Fatalf("expected closed error, got %v", err)
+	}
+}
+
+func TestPipeConnReadEOF(t *testing.T) {
+	t.Parallel()
+
+	readFd, writeFd, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer readFd.Close()
+
+	conn := &PipeConn{
+		reader:  bufio.NewReader(readFd),
+		writer:  writeFd,
+		readFd:  readFd,
+		writeFd: writeFd,
+	}
+
+	// Close write end to simulate Chrome disconnect
+	writeFd.Close()
+
+	var msg cdproto.Message
+	err = conn.Read(context.Background(), &msg)
+	if err != io.EOF {
+		t.Fatalf("expected EOF, got %v", err)
+	}
+}
+
+func TestPipeConnDebugf(t *testing.T) {
+	t.Parallel()
+
+	readFd, writeFd, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer readFd.Close()
+	defer writeFd.Close()
+
+	var debugOutput []string
+	conn := &PipeConn{
+		reader:  bufio.NewReader(readFd),
+		writer:  writeFd,
+		readFd:  readFd,
+		writeFd: writeFd,
+		debugf: func(format string, args ...any) {
+			debugOutput = append(debugOutput, format)
+		},
+	}
+
+	// Test write debug
+	go func() {
+		conn.Write(context.Background(), &cdproto.Message{ID: 1})
+	}()
+
+	// Drain the pipe
+	buf := make([]byte, 1024)
+	readFd.Read(buf)
+
+	if len(debugOutput) != 1 || debugOutput[0] != "-> %s" {
+		t.Fatalf("expected write debug output, got %v", debugOutput)
+	}
+}
+
+func TestPipeConnReadMultiple(t *testing.T) {
+	t.Parallel()
+
+	readFd, writeFd, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer readFd.Close()
+	defer writeFd.Close()
+
+	conn := &PipeConn{
+		reader:  bufio.NewReader(readFd),
+		writer:  writeFd,
+		readFd:  readFd,
+		writeFd: writeFd,
+	}
+
+	go func() {
+		for i := 1; i <= 3; i++ {
+			data := []byte(fmt.Sprintf(`{"id":%d}`, i))
+			writeFd.Write(data)
+			writeFd.Write([]byte{0})
+		}
+	}()
+
+	for i := 1; i <= 3; i++ {
+		var msg cdproto.Message
+		if err := conn.Read(context.Background(), &msg); err != nil {
+			t.Fatal(err)
+		}
+		if msg.ID != int64(i) {
+			t.Fatalf("want id %d, got %d", i, msg.ID)
+		}
+	}
+}
+
+func TestPipeConnConcurrentWrites(t *testing.T) {
+	t.Parallel()
+
+	readFd, writeFd, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer readFd.Close()
+	defer writeFd.Close()
+
+	conn := &PipeConn{
+		reader:  bufio.NewReader(readFd),
+		writer:  writeFd,
+		readFd:  readFd,
+		writeFd: writeFd,
+	}
+
+	// Drain pipe in background
+	go func() {
+		buf := make([]byte, 1)
+		for {
+			if _, err := readFd.Read(buf); err != nil {
+				return
+			}
+		}
+	}()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			conn.Write(context.Background(), &cdproto.Message{ID: int64(id)})
+		}(i)
+	}
+	wg.Wait()
+}
+
+func TestPipeConnReadMalformedJSON(t *testing.T) {
+	t.Parallel()
+
+	readFd, writeFd, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer readFd.Close()
+	defer writeFd.Close()
+
+	conn := &PipeConn{
+		reader:  bufio.NewReader(readFd),
+		writer:  writeFd,
+		readFd:  readFd,
+		writeFd: writeFd,
+	}
+
+	go func() {
+		writeFd.Write([]byte(`{not valid json`))
+		writeFd.Write([]byte{0})
+	}()
+
+	var msg cdproto.Message
+	err = conn.Read(context.Background(), &msg)
+	if err == nil {
+		t.Fatal("expected error for malformed JSON")
+	}
+}
+
+func TestPipeConnDoubleClose(t *testing.T) {
+	t.Parallel()
+
+	readFd, writeFd, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	conn := &PipeConn{
+		reader:  bufio.NewReader(readFd),
+		writer:  writeFd,
+		readFd:  readFd,
+		writeFd: writeFd,
+	}
+
+	if err := conn.Close(); err != nil {
+		t.Fatal(err)
+	}
+	// Second close will error, just verify no panic
+	_ = conn.Close()
+}
+
+func TestPipeConnBrokenPipe(t *testing.T) {
+	t.Parallel()
+
+	readFd, writeFd, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	conn := &PipeConn{
+		reader:  bufio.NewReader(readFd),
+		writer:  writeFd,
+		readFd:  readFd,
+		writeFd: writeFd,
+	}
+
+	// Close read end to simulate broken pipe
+	readFd.Close()
+
+	err = conn.Write(context.Background(), &cdproto.Message{ID: 1})
+	if err == nil {
+		t.Fatal("expected error on broken pipe")
+	}
+}
+
+func TestPipeConnLargeMessage(t *testing.T) {
+	t.Parallel()
+
+	readFd, writeFd, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer readFd.Close()
+	defer writeFd.Close()
+
+	conn := &PipeConn{
+		reader:  bufio.NewReader(readFd),
+		writer:  writeFd,
+		readFd:  readFd,
+		writeFd: writeFd,
+	}
+
+	// 1MB payload
+	largeData := bytes.Repeat([]byte("x"), 1024*1024)
+
+	go func() {
+		msg := []byte(`{"id":1,"result":"` + string(largeData) + `"}`)
+		writeFd.Write(msg)
+		writeFd.Write([]byte{0})
+	}()
+
+	var msg cdproto.Message
+	if err := conn.Read(context.Background(), &msg); err != nil {
+		t.Fatal(err)
+	}
+
+	if msg.ID != 1 {
+		t.Fatalf("want id 1, got %d", msg.ID)
+	}
+}


### PR DESCRIPTION
Fixes #1607

Adds `PipeAllocator` for environments where runtime TCP bind/listen is restricted (gVisor, Firecracker, etc).

Uses Chrome's `--remote-debugging-pipe` flag to communicate over FD 3/4 instead of WebSocket.

## Usage
```go
ctx, cancel := chromedp.NewPipeAllocator(context.Background(),
    chromedp.PipeHeadless,
    chromedp.PipeNoSandbox,
)
defer cancel()

browserCtx, cancel := chromedp.NewContext(ctx)
defer cancel()

chromedp.Run(browserCtx, chromedp.Navigate("https://example.com"))
```

## Changes

- `PipeAllocator` implementing `Allocator` interface
- `PipeConn` implementing `Transport` interface
- `withConn` BrowserOption for pre-established connections
- `DefaultPipeAllocatorOptions` matching ExecAllocator defaults
- Unit and integration tests

Tested locally and in gVisor-sandboxed container (google cloud run).

## Testing

- `go test -run TestPipeAllocator -v` — all pass
- `go test -run TestPipeConn -v` — all pass
- Verified in gVisor-sandboxed container

## Notes

- `TestExecAllocatorMissingWebsocketAddr` fails locally (pre-existing, unrelated to this PR)
- Pipe mode has different kill behavior than WebSocket (documented in test comments).