### PR TITLE
fix: properly handle WebSocket ping/pong frames in Read()

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -73,40 +73,86 @@ func (c *Conn) Close() error {
 func (c *Conn) Read(_ context.Context, msg *cdproto.Message) error {
 	// get websocket reader
 	c.reader = wsutil.Reader{Source: c.conn, State: ws.StateClientSide}
-	h, err := c.reader.NextFrame()
-	if err != nil {
-		return err
-	}
 
-	if h.OpCode == ws.OpPing { // ping
-		if c.debugf != nil {
-			c.debugf("received ping frame, ignoring...")
+	for {
+		h, err := c.reader.NextFrame()
+		if err != nil {
+			return err
 		}
-		return nil
-	} else if h.OpCode == ws.OpClose { // close
-		if c.debugf != nil {
-			c.debugf("received close frame")
+
+		switch h.OpCode {
+		case ws.OpPing:
+			// Read the ping payload and send a pong response
+			if c.debugf != nil {
+				c.debugf("received ping frame, sending pong...")
+			}
+			// Read the ping payload
+			payload := make([]byte, h.Length)
+			if h.Length > 0 {
+				if _, err := io.ReadFull(&c.reader, payload); err != nil {
+					return err
+				}
+			}
+			// Send pong with the same payload (masked for client-side)
+			pongHeader := ws.Header{
+				Fin:    true,
+				OpCode: ws.OpPong,
+				Masked: true,
+				Length: h.Length,
+			}
+			if err := ws.WriteHeader(c.conn, pongHeader); err != nil {
+				return err
+			}
+			if h.Length > 0 {
+				// Write masked payload
+				mask := pongHeader.Mask
+				ws.Cipher(payload, mask, 0)
+				if _, err := c.conn.Write(payload); err != nil {
+					return err
+				}
+			}
+			continue // Read next frame
+
+		case ws.OpPong:
+			// Discard pong payload and continue reading
+			if c.debugf != nil {
+				c.debugf("received pong frame, discarding...")
+			}
+			if h.Length > 0 {
+				if _, err := io.CopyN(io.Discard, &c.reader, h.Length); err != nil {
+					return err
+				}
+			}
+			continue // Read next frame
+
+		case ws.OpClose:
+			if c.debugf != nil {
+				c.debugf("received close frame")
+			}
+			return io.EOF
+
+		case ws.OpText:
+			// This is the expected CDP message, process it
+			var b bytes.Buffer
+			if _, err := b.ReadFrom(&c.reader); err != nil {
+				return err
+			}
+
+			if c.debugf != nil {
+				c.debugf("<- %s", b.Bytes())
+			}
+
+			// unmarshal, reusing decoder
+			c.decoder.Reset(&b, DefaultUnmarshalOptions)
+			return jsonv2.UnmarshalDecode(&c.decoder, msg, DefaultUnmarshalOptions)
+
+		default:
+			if c.debugf != nil {
+				c.debugf("unknown OpCode: %s", h.OpCode)
+			}
+			return ErrInvalidWebsocketMessage
 		}
-		return io.EOF
-	} else if h.OpCode != ws.OpText {
-		if c.debugf != nil {
-			c.debugf("unknown OpCode: %s", h.OpCode)
-		}
-		return ErrInvalidWebsocketMessage
 	}
-
-	var b bytes.Buffer
-	if _, err := b.ReadFrom(&c.reader); err != nil {
-		return err
-	}
-
-	if c.debugf != nil {
-		c.debugf("<- %s", b.Bytes())
-	}
-
-	// unmarshal, reusing decoder
-	c.decoder.Reset(&b, DefaultUnmarshalOptions)
-	return jsonv2.UnmarshalDecode(&c.decoder, msg, DefaultUnmarshalOptions)
 }
 
 // Write writes a message.


### PR DESCRIPTION
### Problem

When connecting to a WebSocket server that sends ping frames (for keep-alive or connection health monitoring), `chromedp` fails with errors like:

```
ERROR: ignoring malformed incoming message (missing id or method): &cdproto.Message{ID:0, SessionID:"", Method:"", ...}
```

The connection then dies, typically within 5-10 seconds of the first ping.

### Root Cause

The current `Read()` implementation in `conn.go` has two issues when handling ping frames:

1. **Doesn't consume the ping payload** - When `OpPing` is received, the code returns `nil` immediately without reading the frame's payload. This leaves the payload bytes in the socket buffer.

2. **Doesn't send a pong response** - Per [RFC 6455 Section 5.5.2](https://datatracker.ietf.org/doc/html/rfc6455#section-5.5.2), upon receiving a ping frame, "an endpoint MUST send a Pong frame in response".

The unconsumed payload corrupts subsequent frame parsing because the next `NextFrame()` call interprets the leftover ping payload as a frame header.

### Fix

This PR:
- Wraps frame reading in a loop to handle control frames inline
- Properly reads the ping payload and sends a masked pong response (as required for client-side WebSocket)
- Discards pong payloads when received (these can arrive if the client also sends pings)
- Continues reading until a data frame (`OpText`) arrives

The implementation follows the pattern from [gobwas/ws autobahn example](https://github.com/gobwas/ws/blob/master/example/autobahn/autobahn.go#L321-L327).

### Reproduction

```go
// Connect to any WebSocket server that sends ping frames
// The connection will fail ~5s after the first ping arrives

allocCtx, _ := chromedp.NewRemoteAllocator(ctx, wsURL, chromedp.NoModifyURL)
taskCtx, _ := chromedp.NewContext(allocCtx)

// Works initially...
chromedp.Run(taskCtx, chromedp.Navigate("https://example.com"))

// ...but fails after server sends first ping
time.Sleep(6 * time.Second)
chromedp.Run(taskCtx, chromedp.Location(&url)) // ERROR: context canceled
```

### Testing

Tested against a production WebSocket proxy that sends ping frames every 5 seconds. Before this fix, connections died at ~5-6s. After this fix, connections remain stable indefinitely.