### PR TITLE
Fix AppArmor failure; make TestPollTimeout fail in time

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,8 @@ jobs:
           sudo apt-get install -y build-essential
       - name: Checkout code
         uses: actions/checkout@v4
+      - name: Disable apparmor
+        run: sudo aa-teardown || true; sudo systemctl disable --now apparmor.service; echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
       - name: Test Chrome
         run: go test -v ./...
       - name: Test headless-shell

--- a/poll_test.go
+++ b/poll_test.go
@@ -222,6 +222,8 @@ func TestPollTimeout(t *testing.T) {
 
 	ctx, cancel := testAllocate(t, "poll.html")
 	defer cancel()
+	ctx, cancel = context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
 
 	if err := Run(ctx, Poll("false", nil, WithPollingTimeout(10*time.Millisecond))); err != ErrPollingTimeout {
 		t.Errorf("got error: %v, want error: %v", err, ErrPollingTimeout)


### PR DESCRIPTION
Currently ChromeDP test fail on CI on some AppArmor nonsense.

I have disabled AppArmor in the CI. Now the AppArmor nonsense doesn't stop ChromeDP anymore.

However, the tests still fail; some of them fail on my local machine too, so it doesn't all seem to be a CI issue anymore. It seems like "actual fails" mostly.

TestPollTimeout now times out forever, which blocks the CI for 10 minutes; I have capped it with `context.WithTimeout`. It still fails, though. (Doesn't fail on my local machine; it can be some timing thing.)