### PR TITLE
add `func WithContext(context.Context, *Context) context.Context`

### DIFF
--- a/chromedp.go
+++ b/chromedp.go
@@ -228,6 +228,10 @@ func FromContext(ctx context.Context) *Context {
 	return c
 }
 
+func WithContext(ctx context.Context, c *Context) context.Context {
+	return context.WithValue(ctx, contextKey{}, c)
+}
+
 // Cancel cancels a chromedp context, waits for its resources to be cleaned up,
 // and returns any error encountered during that process.
 //

--- a/chromedp.go
+++ b/chromedp.go
@@ -228,6 +228,8 @@ func FromContext(ctx context.Context) *Context {
 	return c
 }
 
+// WithContext returns a context derived from the parent context
+// that stores the provided *Context value.
 func WithContext(ctx context.Context, c *Context) context.Context {
 	return context.WithValue(ctx, contextKey{}, c)
 }


### PR DESCRIPTION
For some reasons, I need to store a `Context` and then, when entering a function, inject this `Context` into the first `context.Context` argument.