### PR TITLE
fix(input): drop char event when non-shift modifier is set

### DIFF
--- a/input.go
+++ b/input.go
@@ -170,6 +170,15 @@ func KeyEvent(keys string, opts ...KeyOption) KeyAction {
 				for _, o := range opts {
 					o(k)
 				}
+				// Issue #1384: when a non-shift modifier (Ctrl/Alt/Meta) is
+				// applied, skip the synthesized "char" event. Otherwise the
+				// keyDown fires the accelerator (e.g. Ctrl+A select-all) AND
+				// the char event inserts the literal text ("a") into the
+				// focused field. Shift is preserved because it produces a
+				// printable variant (uppercase) that callers expect.
+				if k.Type == input.KeyChar && k.Modifiers&^input.ModifierShift != 0 {
+					continue
+				}
 				if err := k.Do(ctx); err != nil {
 					return err
 				}

--- a/input_test.go
+++ b/input_test.go
@@ -229,6 +229,54 @@ func TestKeyEvent(t *testing.T) {
 	}
 }
 
+// TestKeyEvent_ModifierDoesNotInsertText is a regression for issue #1384:
+// KeyEvent("a", KeyModifiers(input.ModifierCtrl)) used to fire the Ctrl+A
+// accelerator AND emit a Char event that inserted the literal "a" into the
+// focused field. After the fix, Char events with non-Shift modifiers are
+// suppressed — Ctrl+A selects all and leaves the value untouched.
+func TestKeyEvent_ModifierDoesNotInsertText(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := testAllocate(t, "input.html")
+	defer cancel()
+
+	const seed = "admin123"
+	if err := Run(ctx,
+		Focus(`#input4`, ByID),
+		// clear whatever the fixture pre-populated, then seed a known value
+		KeyEvent(kb.Home),
+		KeyEvent(kb.End, KeyModifiers(input.ModifierShift)),
+		KeyEvent(seed),
+	); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	var before string
+	if err := Run(ctx, Value(`#input4`, &before, ByID)); err != nil {
+		t.Fatalf("read seeded value: %v", err)
+	}
+	if before != seed {
+		t.Fatalf("seed didn't take: got %q, want %q", before, seed)
+	}
+
+	// Send Ctrl+A only — should select-all and leave the value identical.
+	// Pre-fix: a stray Char event with text="a" would replace the selection,
+	// leaving value="a".
+	if err := Run(ctx,
+		KeyEvent("a", KeyModifiers(input.ModifierCtrl)),
+	); err != nil {
+		t.Fatalf("ctrl+a: %v", err)
+	}
+
+	var after string
+	if err := Run(ctx, Value(`#input4`, &after, ByID)); err != nil {
+		t.Fatalf("read post-ctrl+a value: %v", err)
+	}
+	if after != seed {
+		t.Fatalf("Ctrl+A mutated input value (issue #1384): got %q, want %q", after, seed)
+	}
+}
+
 func TestKeyEventNode(t *testing.T) {
 	if os.Getenv("HEADLESS_SHELL") != "" {
 		t.Skip(`Skip in headless-shell due to "Check failed: IsSupportedClipboardBuffer(buffer)"`)


### PR DESCRIPTION
### What this fixes

Closes #1384.

When you send a letter key with `KeyModifiers(input.ModifierCtrl)` (or Alt / Meta), the field gets the literal character typed into it on top of the accelerator firing. Easiest way to reproduce on the existing test page (`testdata/input.html`):

```go
chromedp.Run(ctx,
    chromedp.Focus(`#input4`, chromedp.ByID),
    chromedp.KeyEvent("admin123"),
    chromedp.KeyEvent("a", chromedp.KeyModifiers(input.ModifierCtrl)),
)
// expected: value still "admin123", selection covers it
// actual:   value becomes "a" (the select-all happened, then "a" overwrote it)
```

Same shape as everything in #1384 — works for Ctrl+A on Windows/Linux and Cmd+A on macOS.

### Why it happens

`kb.Encode` emits three events for printable runes: `keyDown` → `keyChar` → `keyUp`. `KeyEvent` then loops through every event and applies the `KeyOption`s (including `KeyModifiers`) to each one in turn:

```go
for _, k := range kb.Encode(r) {
    for _, o := range opts {
        o(k)
    }
    if err := k.Do(ctx); err != nil { return err }
}
```

The `keyChar` event still has `Text` set (e.g. `"a"`). Chrome's input pipeline inserts that text into whatever has focus, regardless of the modifier bits — so the accelerator fires from `keyDown` AND the character gets typed from `keyChar`.

This isn't OS-specific. The only `runtime.GOOS == "darwin"` branch in `kb.Encode` zeroes `NativeVirtualKeyCode`, which doesn't touch the `Text` field. Reproduces on Windows, Linux and macOS as long as you can route a non-Shift modifier to `KeyEvent`.

### The fix

Skip the `keyChar` event whenever a non-Shift modifier is set:

```go
if k.Type == input.KeyChar && k.Modifiers&^input.ModifierShift != 0 {
    continue
}
```

- Shift stays — `KeyEvent("E", KeyModifiers(input.ModifierShift))` still produces an uppercase E, `Shift+End` still selects to end (which `TestKeyEvent` already exercises).
- Ctrl / Alt / Meta combos lose only the synthesized character event. The `keyDown` still carries the modifier bits, so accelerators (select-all, copy, paste, undo, etc.) keep firing.

### Tests

- New: `TestKeyEvent_ModifierDoesNotInsertText` — seeds `"admin123"` into `#input4`, sends `Ctrl+A`, asserts the value is unchanged. Fails on `main`, passes with the fix.
- Existing: `TestKeyEvent` (7 cases incl. `Shift+End` selection), `TestKeyEventNode` (7 cases) all still pass — confirms the fix doesn't regress the printable / Shift paths.

```
$ go test -run "TestKeyEvent$|TestKeyEvent_ModifierDoesNotInsertText|TestKeyEventNode" -v -timeout 180s .
=== RUN   TestKeyEvent
... (7/7 pass)
=== RUN   TestKeyEvent_ModifierDoesNotInsertText
--- PASS: TestKeyEvent_ModifierDoesNotInsertText (0.98s)
=== RUN   TestKeyEventNode
... (7/7 pass)
PASS
ok      github.com/chromedp/chromedp    1.446s
```

### Open questions / things I'm not sure about

- Should `KeyEventNode` get a similar test, or is the unit-level coverage enough? Happy to add one if reviewers prefer.
- The new test doesn't have the `HEADLESS_SHELL` skip the other `KeyEvent` tests use — added it tentatively without the skip because it doesn't touch the clipboard. Let me know if it should match the surrounding style anyway.
