### PR TITLE
Add HTTP header support for remote WebSocket dial

### DIFF
--- a/allocate.go
+++ b/allocate.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -550,8 +551,9 @@ type RemoteAllocatorOption = func(*RemoteAllocator)
 // RemoteAllocator is an Allocator which connects to an already running Chrome
 // process via a websocket URL.
 type RemoteAllocator struct {
-	wsURL         string
-	modifyURLFunc func(ctx context.Context, wsURL string) (string, error)
+	wsURL          string
+	modifyURLFunc  func(ctx context.Context, wsURL string) (string, error)
+	dialHTTPHeader http.Header
 
 	wg sync.WaitGroup
 }
@@ -584,7 +586,11 @@ func (a *RemoteAllocator) Allocate(ctx context.Context, opts ...BrowserOption) (
 		cancel()    // close the websocket connection
 	})
 
-	browser, err := NewBrowser(wctx, wsURL, opts...)
+	browserOpts := opts
+	if a.dialHTTPHeader != nil {
+		browserOpts = append([]BrowserOption{WithDialHTTPHeader(a.dialHTTPHeader)}, opts...)
+	}
+	browser, err := NewBrowser(wctx, wsURL, browserOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -610,4 +616,12 @@ func (a *RemoteAllocator) Wait() {
 // from modifying the websocket debugger URL passed to it.
 func NoModifyURL(a *RemoteAllocator) {
 	a.modifyURLFunc = nil
+}
+
+// WithRemoteDialHTTPHeader is a RemoteAllocatorOption to set HTTP headers on
+// the WebSocket upgrade request when connecting to a remote debugger URL.
+func WithRemoteDialHTTPHeader(h http.Header) RemoteAllocatorOption {
+	return func(a *RemoteAllocator) {
+		a.dialHTTPHeader = h
+	}
 }

--- a/browser.go
+++ b/browser.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net/http"
 	"os"
 	"sync"
 	"sync/atomic"
@@ -53,7 +54,8 @@ type Browser struct {
 	// saving its state to disk.
 	closingGracefully chan struct{}
 
-	dialTimeout time.Duration
+	dialTimeout    time.Duration
+	dialHTTPHeader http.Header
 
 	// pages keeps track of the attached targets, indexed by each's session
 	// ID. The only reason this is a field is so that the tests can check the
@@ -122,7 +124,7 @@ func NewBrowser(ctx context.Context, urlstr string, opts ...BrowserOption) (*Bro
 	}
 
 	var err error
-	b.conn, err = DialContext(dialCtx, urlstr, WithConnDebugf(b.dbgf))
+	b.conn, err = dialContext(dialCtx, urlstr, b.dialHTTPHeader, WithConnDebugf(b.dbgf))
 	if err != nil {
 		return nil, fmt.Errorf("could not dial %q: %w", urlstr, err)
 	}
@@ -373,4 +375,10 @@ func WithConsolef(f func(string, ...any)) BrowserOption {
 // to not use a timeout.
 func WithDialTimeout(d time.Duration) BrowserOption {
 	return func(b *Browser) { b.dialTimeout = d }
+}
+
+// WithDialHTTPHeader is a browser option to set HTTP headers on the
+// WebSocket upgrade request when dialing a remote debugger URL.
+func WithDialHTTPHeader(h http.Header) BrowserOption {
+	return func(b *Browser) { b.dialHTTPHeader = h }
 }

--- a/conn.go
+++ b/conn.go
@@ -1,10 +1,12 @@
 package chromedp
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"io"
 	"net"
+	"net/http"
 
 	"github.com/chromedp/cdproto"
 	jsonv2 "github.com/go-json-experiment/json"
@@ -39,18 +41,37 @@ type Conn struct {
 	debugf func(string, ...any)
 }
 
-// DialContext dials the specified websocket URL using gobwas/ws.
-func DialContext(ctx context.Context, urlstr string, opts ...DialOption) (*Conn, error) {
-	// connect
-	conn, br, _, err := ws.Dial(ctx, urlstr)
+func dialWebSocket(ctx context.Context, urlstr string, header http.Header) (net.Conn, error) {
+	var (
+		conn net.Conn
+		br   *bufio.Reader
+		err  error
+	)
+	if len(header) == 0 {
+		conn, br, _, err = ws.Dial(ctx, urlstr)
+	} else {
+		conn, br, _, err = ws.Dialer{Header: ws.HandshakeHeaderHTTP(header)}.Dial(ctx, urlstr)
+	}
 	if err != nil {
 		return nil, err
 	}
 	if br != nil {
 		panic("br should be nil")
 	}
+	return conn, nil
+}
 
-	// apply opts
+// DialContext dials the specified websocket URL using gobwas/ws.
+func DialContext(ctx context.Context, urlstr string, opts ...DialOption) (*Conn, error) {
+	return dialContext(ctx, urlstr, nil, opts...)
+}
+
+func dialContext(ctx context.Context, urlstr string, header http.Header, opts ...DialOption) (*Conn, error) {
+	conn, err := dialWebSocket(ctx, urlstr, header)
+	if err != nil {
+		return nil, err
+	}
+
 	c := &Conn{
 		conn: conn,
 		// pass 0 to use the default initial buffer size (4KiB).

--- a/conn_test.go
+++ b/conn_test.go
@@ -1,0 +1,68 @@
+package chromedp
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gobwas/ws"
+)
+
+func TestDialHTTPHeader(t *testing.T) {
+	t.Parallel()
+
+	const want = "Bearer secret-token"
+	var got string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.Header.Get("Authorization")
+		conn, _, _, err := ws.UpgradeHTTP(r, w)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		<-time.After(5 * time.Second)
+	}))
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	hdr := http.Header{"Authorization": []string{want}}
+	c, err := dialContext(context.Background(), wsURL, hdr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+
+	if got != want {
+		t.Fatalf("got Authorization %q, want %q", got, want)
+	}
+}
+
+func TestDialHTTPHeaderAbsent(t *testing.T) {
+	t.Parallel()
+
+	var got string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.Header.Get("Authorization")
+		conn, _, _, err := ws.UpgradeHTTP(r, w)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		<-time.After(5 * time.Second)
+	}))
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	c, err := DialContext(context.Background(), wsURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer c.Close()
+
+	if got != "" {
+		t.Fatalf("got Authorization %q, want empty", got)
+	}
+}


### PR DESCRIPTION
## Summary

- Add `WithDialHTTPHeader` browser option to send custom HTTP headers on the WebSocket upgrade request when dialing a CDP endpoint.
- Add `WithRemoteDialHTTPHeader` remote allocator option that forwards headers to the browser dial path.
- Add tests verifying `Authorization` is sent (and absent by default).

## Motivation

Some hosted browser/CDP services (e.g. Cloudflare Browser Rendering) require authenticated WebSocket connections. Today chromedp dials remote debugger URLs without a way to attach headers such as `Authorization: Bearer <token>`, forcing callers to run a local WebSocket proxy.

## Usage

```go
hdr := http.Header{"Authorization": []string{"Bearer " + token}}
allocCtx, cancel := chromedp.NewRemoteAllocator(
    ctx, wsURL,
    chromedp.NoModifyURL,
    chromedp.WithRemoteDialHTTPHeader(hdr),
)
```

## Test plan

- [x] `go test -run TestDialHTTPHeader ./...`
- [x] `go vet ./...`


Made with [Cursor](https://cursor.com)